### PR TITLE
Feat/#36 service 맡은 부분(Article, ArticleLike, Ad, Market, Wish, Subscribe, Club)과 단위테스트 작성

### DIFF
--- a/src/main/java/com/charmroom/charmroom/entity/ArticleLike.java
+++ b/src/main/java/com/charmroom/charmroom/entity/ArticleLike.java
@@ -37,4 +37,8 @@ public class ArticleLike {
         this.user = user;
         this.type = type;
     }
+
+    public void changeType(boolean type) {
+        this.type = type;
+    }
 }

--- a/src/main/java/com/charmroom/charmroom/exception/BusinessLogicError.java
+++ b/src/main/java/com/charmroom/charmroom/exception/BusinessLogicError.java
@@ -13,6 +13,10 @@ public enum BusinessLogicError {
 	UNKNOWN(HttpStatus.BAD_REQUEST, "UNKNOWN", "Unknown"),
 	// end Unknown
 
+	// Ad
+	NOTFOUND_AD(HttpStatus.NOT_FOUND, "00100", "Ad not found"),
+	// end Ad
+
 	// Article
 	NOTFOUND_ARTICLE(HttpStatus.NOT_FOUND, "01100", "Article not found"),
 	// end Article

--- a/src/main/java/com/charmroom/charmroom/exception/BusinessLogicError.java
+++ b/src/main/java/com/charmroom/charmroom/exception/BusinessLogicError.java
@@ -15,6 +15,8 @@ public enum BusinessLogicError {
 	
 	// Image
 	FILE_NOT_IMAGE(HttpStatus.BAD_REQUEST, "08000", "Content type of the file is not image"),
+	// end Image
+
 	// User
 	DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "12000", "Duplicated username"),
 	DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "12001", "Duplicated email"),
@@ -22,7 +24,11 @@ public enum BusinessLogicError {
 	
 	NOTFOUND_USER(HttpStatus.NOT_FOUND, "12100", "User not found"), 
 	// end User
-	
+
+	// Article
+	NOTFOUND_ARTICLE(HttpStatus.NOT_FOUND, "01101", "Article not found"),
+	// end Article
+
 	// ETC
 	MKDIR_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MKDIR_FAIL", "mkdir failed"),
 	CHMOD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "CHMOD_FAIL", "chmod failed")

--- a/src/main/java/com/charmroom/charmroom/exception/BusinessLogicError.java
+++ b/src/main/java/com/charmroom/charmroom/exception/BusinessLogicError.java
@@ -26,7 +26,7 @@ public enum BusinessLogicError {
 	// end User
 
 	// Article
-	NOTFOUND_ARTICLE(HttpStatus.NOT_FOUND, "01101", "Article not found"),
+	NOTFOUND_ARTICLE(HttpStatus.NOT_FOUND, "01100", "Article not found"),
 	// end Article
 
 	// ETC

--- a/src/main/java/com/charmroom/charmroom/exception/BusinessLogicError.java
+++ b/src/main/java/com/charmroom/charmroom/exception/BusinessLogicError.java
@@ -12,7 +12,17 @@ public enum BusinessLogicError {
 	// Unknown
 	UNKNOWN(HttpStatus.BAD_REQUEST, "UNKNOWN", "Unknown"),
 	// end Unknown
-	
+
+	// Article
+	NOTFOUND_ARTICLE(HttpStatus.NOT_FOUND, "01100", "Article not found"),
+	// end Article
+
+	// Club
+	DUPLICATED_CLUBNAME(HttpStatus.BAD_REQUEST, "05000", "Duplicated club name"),
+
+	NOTFOUND_CLUB(HttpStatus.NOT_FOUND, "05100", "Club not found"),
+	// end Club
+
 	// Image
 	FILE_NOT_IMAGE(HttpStatus.BAD_REQUEST, "08000", "Content type of the file is not image"),
 	// end Image
@@ -24,10 +34,6 @@ public enum BusinessLogicError {
 	
 	NOTFOUND_USER(HttpStatus.NOT_FOUND, "12100", "User not found"), 
 	// end User
-
-	// Article
-	NOTFOUND_ARTICLE(HttpStatus.NOT_FOUND, "01100", "Article not found"),
-	// end Article
 
 	// ETC
 	MKDIR_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MKDIR_FAIL", "mkdir failed"),

--- a/src/main/java/com/charmroom/charmroom/repository/ClubRepository.java
+++ b/src/main/java/com/charmroom/charmroom/repository/ClubRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.charmroom.charmroom.entity.Club;
 
-public interface ClubRepository extends JpaRepository<Club, Integer> {
+import java.util.Optional;
 
+public interface ClubRepository extends JpaRepository<Club, Integer> {
+    boolean existsByName(String clubName);
+    Optional<Club> findByName(String clubName);
 }

--- a/src/main/java/com/charmroom/charmroom/service/AdService.java
+++ b/src/main/java/com/charmroom/charmroom/service/AdService.java
@@ -1,0 +1,102 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Ad;
+import com.charmroom.charmroom.entity.Image;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.AdRepository;
+import com.charmroom.charmroom.repository.ImageRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AdService {
+    private final AdRepository adRepository;
+    private final ImageRepository imageRepository;
+    private final CharmroomUtil.Upload uploadUtil;
+
+    public Ad create(String title, String link, MultipartFile imageFile, LocalDateTime startTime, LocalDateTime endTime) {
+        Image image = uploadUtil.buildImage(imageFile);
+        Image savedImage = imageRepository.save(image);
+
+        Ad ad = Ad.builder()
+                .title(title)
+                .link(link)
+                .image(savedImage)
+                .start(startTime)
+                .end(endTime)
+                .build();
+
+        return adRepository.save(ad);
+    }
+
+    public Page<Ad> getAllAdsByPageable(Pageable pageable) {
+        return adRepository.findAll(pageable);
+    }
+
+    @Transactional
+    public Ad updateTitle(Integer adId, String newAdTitle) {
+        Ad ad = adRepository.findById(adId)
+                .orElseThrow(() ->
+                        new BusinessLogicException(BusinessLogicError.NOTFOUND_AD, "adId: " + adId));
+
+        ad.updateTitle(newAdTitle);
+        return ad;
+    }
+
+    @Transactional
+    public Ad updateLink(Integer adId, String newAdLink) {
+        Ad ad = adRepository.findById(adId)
+                .orElseThrow(() ->
+                        new BusinessLogicException(BusinessLogicError.NOTFOUND_AD, "adId: " + adId));
+
+        ad.updateLink(newAdLink);
+        return ad;
+    }
+
+    @Transactional
+    public Ad updateImage(Integer adId, MultipartFile imageFile) {
+        Image image = uploadUtil.buildImage(imageFile);
+        Image savedImage = imageRepository.save(image);
+
+        Ad ad = adRepository.findById(adId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_AD, "adId: " + adId));
+
+        ad.updateImage(savedImage);
+        return ad;
+    }
+
+    @Transactional
+    public Ad updateStartTime(Integer adId, LocalDateTime newStartTime) {
+        Ad ad = adRepository.findById(adId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_AD, "adId: " + adId));
+
+        ad.updateStart(newStartTime);
+        return ad;
+    }
+
+    @Transactional
+    public Ad updateEndTime(Integer adId, LocalDateTime newEndTime) {
+        Ad ad = adRepository.findById(adId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_AD, "adId: " + adId));
+
+        ad.updateEnd(newEndTime);
+        return ad;
+    }
+
+    public void deleteAd(Integer adId) {
+        Ad ad = adRepository.findById(adId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_AD, "adId: " + adId));
+
+        adRepository.delete(ad);
+    }
+}
+

--- a/src/main/java/com/charmroom/charmroom/service/ArticleLikeService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ArticleLikeService.java
@@ -1,0 +1,48 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.ArticleLike;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ArticleLikeRepository;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleLikeService {
+    private final ArticleLikeRepository articleLikeRepository;
+    private final UserRepository userRepository;
+    private final ArticleRepository articleRepository;
+
+    public ArticleLike create(String username, Integer articleId, Boolean type) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new BusinessLogicException(BusinessLogicError.NOTFOUND_USER));
+        Article article = articleRepository.findById(articleId).orElseThrow(() -> new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE));
+
+        Optional<ArticleLike> found = articleLikeRepository.findByUserAndArticle(user, article);
+
+        if (found.isPresent()) {
+            ArticleLike articleLike = found.get();
+            if (articleLike.isType() == type) {
+                articleLikeRepository.delete(articleLike);
+                return null; // 좋아요/싫어요 취소
+            } else {
+                articleLike.changeType(type);
+                return articleLikeRepository.save(articleLike);
+            }
+        } else {
+            return articleLikeRepository.save(
+                    ArticleLike.builder()
+                            .type(type)
+                            .user(user)
+                            .article(article)
+                            .build()
+            );
+        }
+    }
+}

--- a/src/main/java/com/charmroom/charmroom/service/ArticleService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ArticleService.java
@@ -1,0 +1,77 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Attachment;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.AttachmentRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleService {
+    private final ArticleRepository articleRepository;
+    private final AttachmentRepository attachmentRepository;
+    private final CharmroomUtil.Upload uploadUtil;
+
+    public Article createArticle(User user, Board board, String title, String body, List<MultipartFile> fileList) {
+        List<Attachment> attachmentList = new ArrayList<>();
+
+        for (MultipartFile attachment : fileList) {
+            Attachment attachmentEntity = uploadUtil.buildAttachment(attachment);
+            Attachment saved = attachmentRepository.save(attachmentEntity);
+            attachmentList.add(saved);
+        }
+
+        Article article = Article.builder()
+                .title(title)
+                .body(body)
+                .user(user)
+                .board(board)
+                .attachmentList(attachmentList)
+                .build();
+
+        return articleRepository.save(article);
+    }
+
+    public Page<Article> getAllArticlesByPageable(Pageable pageable) {
+        return articleRepository.findAll(pageable);
+    }
+
+    public Article getOneArticle(Integer articleId) {
+        return articleRepository.findById(articleId)
+                .orElseThrow(() -> new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "articleId: " + articleId)
+                );
+    }
+
+    @Transactional
+    public Article updateArticle(Integer articleId, Article updated) {
+        Article originalArticle = articleRepository.findById(articleId).orElseThrow(
+                () -> new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "articleId: " + articleId)
+        );
+        originalArticle.updateTitle(updated.getTitle());
+        originalArticle.updatedBody(updated.getBody());
+
+        return originalArticle;
+    }
+
+    public void deleteArticle(Integer articleId) {
+        Article found = articleRepository.findById(articleId).orElseThrow(
+                () -> new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "articleId: " + articleId)
+        );
+
+        articleRepository.delete(found);
+    }
+}

--- a/src/main/java/com/charmroom/charmroom/service/ClubService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ClubService.java
@@ -1,0 +1,95 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Club;
+import com.charmroom.charmroom.entity.Image;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ClubRepository;
+import com.charmroom.charmroom.repository.ImageRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ClubService {
+    private final ClubRepository clubRepository;
+    private final ImageRepository imageRepository;
+    private final CharmroomUtil.Upload uploadUtil;
+
+    public Club createClub(String clubName, String description, String contact) {
+        if(isDuplicateClubName(clubName)) throw new BusinessLogicException(BusinessLogicError.DUPLICATED_CLUBNAME);
+
+        Club club = Club.builder()
+                .name(clubName)
+                .description(description)
+                .contact(contact)
+                .build();
+
+        return clubRepository.save(club);
+    }
+
+    public boolean isDuplicateClubName(String clubName) {
+        return clubRepository.existsByName(clubName);
+    }
+
+    public Page<Club> getAllClubsByPageable(PageRequest pageRequest) {
+        return clubRepository.findAll(pageRequest);
+    }
+
+    public Club getClub(Integer clubId) {
+        return clubRepository.findById(clubId)
+                .orElseThrow(() ->
+                        new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId)
+                );
+    }
+
+    @Transactional
+    public Club updateClubName(Integer clubId, String newClubName) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId)
+        );
+
+        club.updateName(newClubName);
+        return club;
+    }
+
+    @Transactional
+    public Club updateDescription(Integer clubId, String newClubDescription) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        club.updateDescription(newClubDescription);
+        return club;
+    }
+
+    public Club updateContact(Integer clubId, String newClubContact) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        club.updateContact(newClubContact);
+        return club;
+    }
+
+    public void deleteClub(Integer clubId) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        clubRepository.delete(club);
+    }
+
+    public Club setImage(String clubName, MultipartFile imageFile) {
+        Club club = clubRepository.findByName(clubName).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubName: " + clubName));
+
+        Image image = uploadUtil.buildImage(imageFile);
+        Image saved = imageRepository.save(image);
+
+        club.updateImage(saved);
+        return club;
+    }
+}

--- a/src/main/java/com/charmroom/charmroom/service/MarketService.java
+++ b/src/main/java/com/charmroom/charmroom/service/MarketService.java
@@ -1,0 +1,77 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Market;
+import com.charmroom.charmroom.entity.enums.MarketArticleState;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.MarketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MarketService {
+    private final MarketRepository marketRepository;
+    private final ArticleRepository articleRepository;
+
+    public Market create(Article article, Integer price, String tag, MarketArticleState state) {
+        Market market = Market.builder()
+                .article(article)
+                .price(price)
+                .tag(tag)
+                .state(state)
+                .build();
+
+        return marketRepository.save(market);
+    }
+
+    public Page<Market> getAllMarketsByPageable(Pageable pageable) {
+        return marketRepository.findAll(pageable);
+    }
+
+    public Market getMarket(Integer marketId) {
+        return marketRepository.findById(marketId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "marketId: " + marketId));
+    }
+
+    @Transactional
+    public Market updatePrice(Integer marketId, int price) {
+        Market market = marketRepository.findById(marketId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "marketId: " + marketId));
+
+        market.updatePrice(price);
+        return market;
+    }
+
+    @Transactional
+    public Market updateTag(Integer marketId, String newTag) {
+        Market market = marketRepository.findById(marketId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "marketId: " + marketId));
+
+        market.updateTag(newTag);
+        return market;
+    }
+
+    @Transactional
+    public Market updateState(Integer marketId, MarketArticleState newState) {
+        Market market = marketRepository.findById(marketId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "marketId: " + marketId));
+
+        market.updateState(newState);
+        return market;
+    }
+
+    public void delete(Integer marketId) {
+        Market market = marketRepository.findById(marketId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "marketId: " + marketId));
+
+        Article article = market.getArticle();
+        articleRepository.delete(article);
+        marketRepository.delete(market);
+    }
+}

--- a/src/main/java/com/charmroom/charmroom/service/SubscribeService.java
+++ b/src/main/java/com/charmroom/charmroom/service/SubscribeService.java
@@ -1,0 +1,41 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Subscribe;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.SubscribeRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SubscribeService {
+    private final SubscribeRepository subscribeRepository;
+    private final UserRepository userRepository;
+
+    public Subscribe create(String subscriberName, String targetName) {
+        User subscriber = userRepository.findByUsername(subscriberName).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_USER, "subscriberName: " + subscriberName));
+        User target = userRepository.findByUsername(targetName).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_USER, "targetName: " + targetName));
+
+        Optional<Subscribe> found = subscribeRepository.findBySubscriberAndTarget(subscriber, target);
+
+        if (found.isPresent()) {
+            Subscribe subscribe = found.get();
+            subscribeRepository.delete(subscribe);
+            return null; // 구독 취소
+        } else {
+            return subscribeRepository.save(
+                    Subscribe.builder()
+                            .subscriber(subscriber)
+                            .target(target)
+                            .build()
+            );
+        }
+    }
+}

--- a/src/main/java/com/charmroom/charmroom/service/WishService.java
+++ b/src/main/java/com/charmroom/charmroom/service/WishService.java
@@ -1,0 +1,44 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Market;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.Wish;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.MarketRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+import com.charmroom.charmroom.repository.WishRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WishService {
+    private final WishRepository wishRepository;
+    private final UserRepository userRepository;
+    private final MarketRepository marketRepository;
+
+    public Wish create(String username, Integer marketId) {
+        User user = userRepository.findByUsername(username).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_USER));
+        Market market = marketRepository.findById(marketId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE));
+
+        Optional<Wish> found = wishRepository.findByUserAndMarket(user, market);
+
+        if (found.isPresent()) {
+            Wish wish = found.get();
+            wishRepository.delete(wish);
+            return null; // 찜하기 취소
+        } else {
+            return wishRepository.save(
+                    Wish.builder()
+                            .user(user)
+                            .market(market)
+                            .build()
+            );
+        }
+    }
+}

--- a/src/test/java/com/charmroom/charmroom/service/AdServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/AdServiceUnitTest.java
@@ -1,0 +1,267 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Ad;
+import com.charmroom.charmroom.entity.Image;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.AdRepository;
+import com.charmroom.charmroom.repository.ImageRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class AdServiceUnitTest {
+    @Mock
+    AdRepository adRepository;
+    @Mock
+    ImageRepository imageRepository;
+    @Mock
+    private CharmroomUtil.Upload uploadUtil;
+    @InjectMocks
+    AdService adService;
+
+    private Ad ad;
+    private String title;
+    private String link;
+    private Image image;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private int adId;
+
+    Image createImage() {
+        return Image.builder()
+                .path("")
+                .originalName("")
+                .build();
+    }
+
+    Ad createAd(String prefix) {
+        return Ad.builder()
+                .id(adId)
+                .title(prefix + title)
+                .link(link)
+                .image(image)
+                .start(startTime)
+                .end(endTime)
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        adId = 1;
+        title = "ad title";
+        link = "ad link";
+        startTime = LocalDateTime.of(2024, 1, 1, 0, 0);
+        endTime = LocalDateTime.of(2024, 1, 2, 0, 0);
+        image = createImage();
+        ad = createAd("");
+    }
+
+    @Nested
+    @DisplayName("create Ad")
+    class CreateAd {
+        @Test
+        void success() {
+            // given
+            MultipartFile imageFile = new MockMultipartFile("file", "test.png", "image/png", "test".getBytes());
+
+            doReturn(image).when(uploadUtil).buildImage(imageFile);
+            doReturn(image).when(imageRepository).save(image);
+            doReturn(ad).when(adRepository).save(any(Ad.class));
+
+            // when
+            Ad created = adService.create(title, link, imageFile, startTime, endTime);
+
+            // then
+            assertThat(created).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Get Ad List")
+    class GetAdList {
+        @Test
+        void success() {
+            // given
+            List<Ad> adList = List.of(createAd("1"), createAd("2"), createAd("3"));
+            PageRequest pageRequest = PageRequest.of(0, 3, Sort.Direction.DESC, "startTime");
+            PageImpl<Ad> adPage = new PageImpl<>(adList);
+
+            doReturn(adPage).when(adRepository).findAll(pageRequest);
+
+            // when
+            Page<Ad> allAdsByPageable = adService.getAllAdsByPageable(pageRequest);
+
+            // then
+            assertThat(allAdsByPageable).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Update title")
+    class UpdateTitle {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(ad)).when(adRepository).findById(ad.getId());
+
+            // when
+            Ad updated = adService.updateTitle(ad.getId(), "new ad title");
+
+            // then
+            assertThat(updated.getTitle()).isEqualTo("new ad title");
+        }
+
+        @Test
+        void fail_AdNotFound() {
+            // given
+            doReturn(Optional.empty()).when(adRepository).findById(adId);
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () ->
+                    adService.updateTitle(adId, "new ad title"));
+
+            // then
+            assertThat(thrown).isInstanceOf(BusinessLogicException.class);
+            assertThat(thrown.getMessage()).isEqualTo("adId: " + adId);
+        }
+    }
+
+    @Nested
+    @DisplayName("Update link")
+    class UpdateLink {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(ad)).when(adRepository).findById(adId);
+
+            // when
+            Ad updated = adService.updateLink(adId, "new ad link");
+
+            // then
+            assertThat(updated.getLink()).isEqualTo("new ad link");
+        }
+
+        @Test
+        void fail_AdNotFound() {
+            // given
+            doReturn(Optional.empty()).when(adRepository).findById(adId);
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () ->
+                    adService.updateLink(adId, "new ad link"));
+
+            // then
+            assertThat(thrown).isInstanceOf(BusinessLogicException.class);
+            assertThat(thrown.getMessage()).isEqualTo("adId: " + adId);
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Image")
+    class UpdateImage {
+        @Test
+        void success() {
+            // given
+            MultipartFile imageFile = new MockMultipartFile("new file", "test.png", "image/png", "test".getBytes());
+            Image image = Image.builder().build();
+
+            doReturn(image).when(uploadUtil).buildImage(imageFile);
+            doReturn(image).when(imageRepository).save(image);
+            doReturn(Optional.of(ad)).when(adRepository).findById(adId);
+
+            // when
+            Ad updated = adService.updateImage(adId, imageFile);
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getImage()).isEqualTo(image);
+        }
+
+        @Test
+        void fail_AdNotFound() {
+            // given
+            MultipartFile imageFile = new MockMultipartFile("new file", "test.png", "image/png", "test".getBytes());
+
+            doReturn(Optional.empty()).when(adRepository).findById(adId);
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () ->
+                    adService.updateImage(adId, imageFile));
+
+            // then
+            assertThat(thrown).isInstanceOf(BusinessLogicException.class);
+            assertThat(thrown.getMessage()).isEqualTo("adId: " + adId);
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Time")
+    class UpdateTime {
+        @Test
+        void success_updateStartTime() {
+            // given
+            doReturn(Optional.of(ad)).when(adRepository).findById(adId);
+            LocalDateTime newStartTime = LocalDateTime.of(2024, 1, 6, 0, 0);
+
+            // when
+            Ad updated = adService.updateStartTime(adId, newStartTime);
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getStart()).isEqualTo(newStartTime);
+        }
+
+        @Test
+        void success_updateEndTime() {
+            // given
+            doReturn(Optional.of(ad)).when(adRepository).findById(adId);
+            LocalDateTime newEndTime = LocalDateTime.of(2024, 12, 1, 0, 0);
+
+            // when
+            Ad updated = adService.updateEndTime(adId, newEndTime);
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getEnd()).isEqualTo(newEndTime);
+        }
+    }
+
+    @Nested
+    @DisplayName("Delete Ad")
+    class DeleteAd {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(ad)).when(adRepository).findById(adId);
+
+            // when
+            adService.deleteAd(adId);
+
+            // then
+            verify(adRepository).delete(ad);
+        }
+    }
+}

--- a/src/test/java/com/charmroom/charmroom/service/ArticleLikeServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ArticleLikeServiceUnitTest.java
@@ -1,0 +1,226 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.ArticleLike;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.enums.BoardType;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ArticleLikeRepository;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleLikeServiceUnitTest {
+    @Mock
+    private ArticleLikeRepository articleLikeRepository;
+    @Mock
+    private ArticleRepository articleRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Spy
+    private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    @InjectMocks
+    private ArticleLikeService articleLikeService;
+
+    private Article article;
+    private User user;
+    private ArticleLike articleLike;
+    private ArticleLike articleDislike;
+    private Board board;
+    private String title;
+    private String body;
+
+    private User createUser() {
+        return User.builder()
+                .id(1)
+                .username("username")
+                .nickname("nickname")
+                .email("email@example.com")
+                .password(passwordEncoder.encode("password"))
+                .build();
+    }
+
+    private Board createBoard() {
+        return Board.builder()
+                .type(BoardType.LIST)
+                .exposed(false)
+                .build();
+    }
+
+    private Article createArticle() {
+        user = createUser();
+        board = createBoard();
+
+        return Article.builder()
+                .id(1)
+                .title(title)
+                .body(body)
+                .user(user)
+                .board(board)
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        title = "test title";
+        body = "test body";
+        user = createUser();
+        board = createBoard();
+        article = createArticle();
+
+        articleLike = ArticleLike.builder()
+                .article(article)
+                .type(true)
+                .user(user)
+                .build();
+
+        articleDislike = ArticleLike.builder()
+                .article(article)
+                .user(user)
+                .type(false)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Add Like")
+    class addLike {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(user.getUsername());
+            doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
+            doReturn(articleLike).when(articleLikeRepository).save(any(ArticleLike.class));
+            doReturn(Optional.empty()).when(articleLikeRepository).findByUserAndArticle(user, article);
+
+            // when
+            ArticleLike like = articleLikeService.create(user.getUsername(), article.getId(), true);
+
+            // then
+            verify(articleLikeRepository).save(any(ArticleLike.class));
+            assertThat(like).isNotNull();
+        }
+
+        @Test
+        void AddLikeWhenOriginalTypeIsTrue() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(user.getUsername());
+            doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
+
+            when(articleLikeRepository.findByUserAndArticle(user, article)).thenReturn(Optional.of(articleLike));
+
+            // when
+            ArticleLike like = articleLikeService.create(user.getUsername(), article.getId(), true);
+            // then
+            verify(articleLikeRepository).delete(any(ArticleLike.class));
+            assertNull(like);
+        }
+
+        @Test
+        void AddLikeWhenOriginalTypeIsFalse() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(user.getUsername());
+            doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
+            doReturn(articleLike).when(articleLikeRepository).save(any(ArticleLike.class));
+
+            when(articleLikeRepository.findByUserAndArticle(user, article)).thenReturn(Optional.of(articleDislike));
+
+            // when
+            ArticleLike like = articleLikeService.create(user.getUsername(), article.getId(), true);
+
+            // then
+            assertThat(like.isType()).isEqualTo(true);
+            verify(articleLikeRepository).save(any(ArticleLike.class));
+        }
+
+        @Test
+        void fail_notExistingArticle() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(user.getUsername());
+            doReturn(Optional.empty()).when(articleRepository).findById(article.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> {
+                articleLikeService.create(user.getUsername(), article.getId(), true);
+            });
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_ARTICLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("Add Dislike")
+    class addDislike {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(user.getUsername());
+            doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
+            doReturn(articleDislike).when(articleLikeRepository).save(any(ArticleLike.class));
+            doReturn(Optional.empty()).when(articleLikeRepository).findByUserAndArticle(user, article);
+
+            // when
+            ArticleLike dislike = articleLikeService.create(user.getUsername(), article.getId(), false);
+
+            // then
+            verify(articleLikeRepository).save(any(ArticleLike.class));
+            assertThat(dislike).isNotNull();
+        }
+
+        @Test
+        void AddDislikeWhenOriginalTypeIsFalse() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(user.getUsername());
+            doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
+
+            when(articleLikeRepository.findByUserAndArticle(user, article)).thenReturn(Optional.of(articleDislike));
+
+            // when
+            ArticleLike like = articleLikeService.create(user.getUsername(), article.getId(), false);
+
+            // then
+            verify(articleLikeRepository).delete(any(ArticleLike.class));
+            assertNull(like);
+        }
+
+        @Test
+        void AddDislikeWhenOriginalTypeIsTrue() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(user.getUsername());
+            doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
+
+            doReturn(articleDislike).when(articleLikeRepository).save(any(ArticleLike.class));
+            when(articleLikeRepository.findByUserAndArticle(user, article)).thenReturn(Optional.of(articleLike));
+
+            // when
+            ArticleLike like = articleLikeService.create(user.getUsername(), article.getId(), false);
+
+            // then
+            assertThat(like.isType()).isEqualTo(false);
+            verify(articleLikeRepository).save(any(ArticleLike.class));
+        }
+    }
+}

--- a/src/test/java/com/charmroom/charmroom/service/ArticleServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ArticleServiceUnitTest.java
@@ -1,0 +1,301 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Attachment;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.enums.AttachmentType;
+import com.charmroom.charmroom.entity.enums.BoardType;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.AttachmentRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleServiceUnitTest {
+    @Mock
+    private ArticleRepository articleRepository;
+    @Mock
+    private AttachmentRepository attachmentRepository;
+    @Mock
+    private CharmroomUtil.Upload uploadUtil;
+    @Spy
+    private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    @InjectMocks
+    private ArticleService articleService;
+
+    private Article article;
+    private User user;
+    private Board board;
+    private String title;
+    private String body;
+    private List<MultipartFile> fileList;
+    private Attachment attachment1;
+    private Attachment attachment2;
+    private Attachment attachment3;
+    private MultipartFile multipartFile1;
+    private MultipartFile multipartFile2;
+    private MultipartFile multipartFile3;
+
+    private User createUser() {
+        return User.builder()
+                .username("username")
+                .nickname("nickname")
+                .email("email@example.com")
+                .password(passwordEncoder.encode("password"))
+                .build();
+    }
+
+    private Board createBoard() {
+        return Board.builder()
+                .type(BoardType.LIST)
+                .exposed(false)
+                .build();
+    }
+
+    private Article createArticle(String prefix) {
+        user = createUser();
+        board = createBoard();
+
+        return Article.builder()
+                .title(prefix + title)
+                .body(prefix + body)
+                .user(user)
+                .board(board)
+                .build();
+    }
+
+    private Attachment createAttachment(String prefix) {
+        return Attachment.builder()
+                .path(prefix + "path")
+                .type(AttachmentType.IMAGE)
+                .originalName(prefix + "originalName")
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        int articleId = 1;
+        title = "test title";
+        body = "test body";
+        user = createUser();
+        board = createBoard();
+
+        multipartFile1 = new MockMultipartFile("file", "test.png", "image/png", "test".getBytes());
+        multipartFile2 = new MockMultipartFile("file", "test.png", "image/png", "test".getBytes());
+        multipartFile3 = new MockMultipartFile("file", "test.png", "image/png", "test".getBytes());
+
+        attachment1 = createAttachment("attachment1");
+        attachment2 = createAttachment("attachment2");
+        attachment3 = createAttachment("attachment3");
+        fileList = List.of(multipartFile1, multipartFile2, multipartFile3);
+        List<Attachment> attachmentList = List.of(attachment1, attachment2, attachment3);
+
+        article = Article.builder()
+                .id(articleId)
+                .title(title)
+                .body(body)
+                .board(board)
+                .user(user)
+                .attachmentList(attachmentList)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Create Article")
+    class createArticle {
+        @Test
+        void success() {
+            // given
+            doReturn(attachment1).when(uploadUtil).buildAttachment(multipartFile1);
+            doReturn(attachment2).when(uploadUtil).buildAttachment(multipartFile2);
+            doReturn(attachment3).when(uploadUtil).buildAttachment(multipartFile3);
+            doReturn(attachment1).when(attachmentRepository).save(attachment1);
+            doReturn(attachment2).when(attachmentRepository).save(attachment2);
+            doReturn(attachment3).when(attachmentRepository).save(attachment3);
+            doReturn(article).when(articleRepository).save(any(Article.class));
+
+            // when
+            Article saved = articleService.createArticle(user, board, title, body, fileList);
+
+            // then
+            verify(articleRepository).save(any(Article.class));
+            assertThat(saved).isNotNull();
+            assertThat(saved.getBody().equals(article.getBody())).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Read ArticleList")
+    class readArticleList {
+        @Test
+        void success() {
+            // given
+            List<Article> articleList = List.of(createArticle("1"), createArticle("2"), createArticle("3"));
+            PageRequest pageRequest = PageRequest.of(0, 3, Sort.Direction.ASC, "title");
+            PageImpl<Article> articlePage = new PageImpl<>(articleList);
+
+            doReturn(articlePage).when(articleRepository).findAll(pageRequest);
+
+            // when
+            Page<Article> articles = articleService.getAllArticlesByPageable(pageRequest);
+
+            // then
+            verify(articleRepository).findAll(pageRequest);
+            assertThat(articles).hasSize(3);
+            assertThat(articles.stream().toList().get(0)).isEqualTo(articleList.get(0));
+        }
+
+        @Test
+        void fail_noArticlesFound() {
+            // given
+            PageRequest pageRequest = PageRequest.of(0, 3, Sort.Direction.ASC, "title");
+            PageImpl<Article> articlePage = new PageImpl<>(List.of());
+
+            doReturn(articlePage).when(articleRepository).findAll(pageRequest);
+
+            // when
+            Page<Article> articles = articleService.getAllArticlesByPageable(pageRequest);
+
+            // then
+            verify(articleRepository).findAll(pageRequest);
+            assertThat(articles).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Get One Article")
+    class getOneArticle {
+        @Test
+        void success() {
+            // given
+            when(articleRepository.findById(article.getId())).thenReturn(Optional.of(article));
+
+            // when
+            Article found = articleService.getOneArticle(article.getId());
+
+            // then
+            verify(articleRepository).findById(article.getId());
+            assertThat(found).isNotNull();
+            assertThat(found.getTitle()).isEqualTo(article.getTitle());
+        }
+
+        @Test
+        void fail_noArticleFound() {
+            // given
+            doReturn(Optional.empty()).when(articleRepository).findById(article.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () ->
+                    articleService.getOneArticle(article.getId()));
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_ARTICLE);
+            assertThat(thrown.getMessage()).isEqualTo("articleId: " + article.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Article")
+    class updateArticle {
+        @Test
+        void success() {
+            // given
+            Article updated = Article.builder()
+                    .title("updated")
+                    .body("updated")
+                    .build();
+
+            doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
+
+            // when
+            Article updatedArticle = articleService.updateArticle(article.getId(), updated);
+
+            // then
+            verify(articleRepository).findById(article.getId());
+            assertThat(updatedArticle.getTitle()).isEqualTo(updated.getTitle());
+            assertThat(updatedArticle.getBody()).isEqualTo(updated.getBody());
+        }
+
+        @Test
+        void fail_noArticleFound() {
+            // given
+            Article updated = Article.builder()
+                    .title("updated")
+                    .body("updated")
+                    .build();
+
+            doReturn(Optional.empty()).when(articleRepository).findById(article.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () ->
+                    articleService.updateArticle(article.getId(), updated)
+            );
+
+            // then
+            verify(articleRepository).findById(article.getId());
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_ARTICLE);
+            assertThat(thrown.getMessage()).isEqualTo("articleId: " + article.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Delete Article")
+    class deleteArticle {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
+
+            // when
+            articleService.deleteArticle(article.getId());
+
+            // then
+            verify(articleRepository).findById(article.getId());
+            verify(articleRepository).delete(article);
+        }
+
+        @Test
+        void fail_noArticleFound() {
+            // given
+            doReturn(Optional.empty()).when(articleRepository).findById(article.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () ->
+                    articleService.deleteArticle(article.getId()));
+
+            // then
+            verify(articleRepository).findById(article.getId());
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_ARTICLE);
+            assertThat(thrown.getMessage()).isEqualTo("articleId: " + article.getId());
+        }
+    }
+}

--- a/src/test/java/com/charmroom/charmroom/service/ClubServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ClubServiceUnitTest.java
@@ -1,0 +1,319 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Club;
+import com.charmroom.charmroom.entity.Image;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ClubRepository;
+import com.charmroom.charmroom.repository.ImageRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class ClubServiceUnitTest {
+    @Mock
+    ClubRepository clubRepository;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    ImageRepository imageRepository;
+    @Mock
+    private CharmroomUtil.Upload uploadUtil;
+    @InjectMocks
+    ClubService clubService;
+
+    private Club club;
+    private String clubName;
+    private String description;
+    private String contact;
+    private int clubId;
+    private String username;
+    private User user;
+
+    private User createUser(String prefix) {
+        return User.builder()
+                .username(prefix + username)
+                .build();
+    }
+
+    private Club createClub(String prefix) {
+        return Club.builder()
+                .id(clubId)
+                .name(prefix + clubName)
+                .description(description)
+                .contact(contact)
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        clubId = 1;
+        clubName = "club name";
+        description = "club description";
+        contact = "club contact";
+        club = createClub("");
+        user = createUser("");
+    }
+
+    @Nested
+    @DisplayName("Create Club")
+    class CreateClub {
+        @Test
+        void success() {
+            // given
+            doReturn(club).when(clubRepository).save(any(Club.class));
+            doReturn(false).when(clubRepository).existsByName(clubName);
+
+            // when
+            Club created = clubService.createClub(clubName, description, contact);
+
+            // then
+            verify(clubRepository).save(any(Club.class));
+            assertThat(created).isNotNull();
+        }
+
+        @Test
+        void fail_ClubNameDuplicated() {
+            // given
+            doReturn(true).when(clubRepository).existsByName(clubName);
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () ->
+                    clubService.createClub(clubName, description, contact));
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.DUPLICATED_CLUBNAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("Get Club List")
+    class getClubList {
+        @Test
+        void success() {
+            // given
+            List<Club> clubList = List.of(createClub("1"), createClub("2"), createClub("3"));
+            PageRequest pageRequest = PageRequest.of(0, 3, Sort.Direction.ASC, "clubName");
+            PageImpl<Club> clubPage = new PageImpl<>(clubList);
+
+            doReturn(clubPage).when(clubRepository).findAll(pageRequest);
+
+            // when
+            Page<Club> allClubsByPageable = clubService.getAllClubsByPageable(pageRequest);
+
+            // then
+            assertThat(allClubsByPageable).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Get Club")
+    class getClub {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
+
+            // when
+            Club found = clubService.getClub(club.getId());
+
+            // then
+            assertThat(found).isNotNull();
+        }
+
+        @Test
+        void fail_ClubNotFound() {
+            // given
+            doReturn(Optional.empty()).when(clubRepository).findById(club.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> clubService.getClub(club.getId()));
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_CLUB);
+            assertThat(thrown.getMessage()).isEqualTo("clubId: " + club.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Club Name")
+    class updateClubName {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
+
+            // when
+            Club updated = clubService.updateClubName(club.getId(), "new club name");
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getName()).isEqualTo("new club name");
+        }
+
+        @Test
+        void fail_ClubNotFound() {
+            // given
+            doReturn(Optional.empty()).when(clubRepository).findById(club.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> clubService.updateClubName(club.getId(), "new club name"));
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_CLUB);
+            assertThat(thrown.getMessage()).isEqualTo("clubId: " + club.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Description")
+    class updateDescription {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
+
+            // when
+            Club updated = clubService.updateDescription(club.getId(), "new club description");
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getDescription()).isEqualTo("new club description");
+        }
+
+        @Test
+        void fail_ClubNotFound() {
+            // given
+            doReturn(Optional.empty()).when(clubRepository).findById(club.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> clubService.updateDescription(club.getId(), "new club description"));
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_CLUB);
+            assertThat(thrown.getMessage()).isEqualTo("clubId: " + club.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Contact")
+    class updateContact {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
+
+            // when
+            Club updated = clubService.updateContact(club.getId(), "new club contact");
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getContact()).isEqualTo("new club contact");
+        }
+
+        @Test
+        void fail_ClubNotFound() {
+            // given
+            doReturn(Optional.empty()).when(clubRepository).findById(club.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> clubService.updateContact(club.getId(), "new club contact"));
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_CLUB);
+            assertThat(thrown.getMessage()).isEqualTo("clubId: " + club.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Delete Club")
+    class deleteClub {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
+
+            // when
+            clubService.deleteClub(club.getId());
+
+            // then
+            verify(clubRepository).delete(any(Club.class));
+        }
+
+        @Test
+        void fail_ClubNotFound() {
+            // given
+            doReturn(Optional.empty()).when(clubRepository).findById(club.getId());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> {
+                clubService.deleteClub(club.getId());
+            });
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_CLUB);
+            assertThat(thrown.getMessage()).isEqualTo("clubId: " + club.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Set Image")
+    class setImage {
+        @Test
+        void success() {
+            // given
+            MockMultipartFile imageFile = new MockMultipartFile("file", "test.png", "image/png", "test".getBytes());
+            Image image = Image.builder()
+                    .path("")
+                    .originalName("")
+                    .build();
+
+            doReturn(Optional.of(club)).when(clubRepository).findByName(club.getName());
+            doReturn(image).when(uploadUtil).buildImage(imageFile);
+            doReturn(image).when(imageRepository).save(image);
+
+            // when
+            Club updated = clubService.setImage(club.getName(), imageFile);
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getImage()).isEqualTo(image);
+        }
+
+        @Test
+        void fail_ClubNotFound() {
+            // given
+            MockMultipartFile imageFile = new MockMultipartFile("file", "test.png", "image/png", "test".getBytes());
+            doReturn(Optional.empty()).when(clubRepository).findByName(club.getName());
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> {
+                clubService.setImage(club.getName(), imageFile);
+            });
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_CLUB);
+        }
+    }
+}

--- a/src/test/java/com/charmroom/charmroom/service/MarketServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/MarketServiceUnitTest.java
@@ -1,0 +1,227 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.Market;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.enums.MarketArticleState;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.MarketRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class MarketServiceUnitTest {
+    @Mock
+    MarketRepository marketRepository;
+    @Mock
+    ArticleRepository articleRepository;
+    @InjectMocks
+    MarketService marketService;
+
+    private Market market;
+    private User user;
+    private Board board;
+    private Article article;
+    private int price;
+    private String tag;
+    private int marketId;
+    private MarketArticleState state;
+
+    Article createArticle() {
+        return Article.builder()
+                .title("title")
+                .body("body")
+                .user(user)
+                .board(board)
+                .build();
+    }
+
+    Market createMarket(int prefix) {
+        return Market.builder()
+                .id(prefix + marketId)
+                .article(article)
+                .price(price)
+                .tag(tag)
+                .state(state)
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        price = 10000;
+        tag = "new product";
+        marketId = 0;
+        state = MarketArticleState.SALE;
+        article = createArticle();
+        market = createMarket(0);
+    }
+
+    @Nested
+    @DisplayName("Create Market")
+    class CreateMarket {
+        @Test
+        void success() {
+            // given
+            doReturn(market).when(marketRepository).save(any(Market.class));
+
+            // when
+            Market created = marketService.create(article, price, tag, state);
+
+            // then
+            assertThat(created).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Get Market List")
+    class GetMarketList {
+        @Test
+        void success() {
+            // given
+            var marketList = List.of(createMarket(1), createMarket(2), createMarket(3));
+            PageRequest pageRequest = PageRequest.of(0, 3, Sort.Direction.ASC, "id");
+            var marketPage = new PageImpl<>(marketList);
+
+            doReturn(marketPage).when(marketRepository).findAll(pageRequest);
+
+            // when
+            Page<Market> result = marketService.getAllMarketsByPageable(pageRequest);
+
+            // then
+            assertThat(result).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Get Market")
+    class GetMarket {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(market)).when(marketRepository).findById(marketId);
+
+            // when
+            Market found = marketService.getMarket(marketId);
+
+            // then
+            assertThat(found).isNotNull();
+            assertThat(found.getId()).isEqualTo(marketId);
+        }
+
+        @Test
+        void fail_NotFoundArticle() {
+            // given
+            doReturn(Optional.empty()).when(marketRepository).findById(marketId);
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> marketService.getMarket(marketId));
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_ARTICLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Price")
+    class UpdatePrice {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(market)).when(marketRepository).findById(marketId);
+
+            // when
+            Market updated = marketService.updatePrice(marketId, 20000);
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getPrice()).isEqualTo(20000);
+        }
+    }
+
+    @Nested
+    @DisplayName("Update Tag")
+    class UpdateTag {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(market)).when(marketRepository).findById(marketId);
+
+            // when
+            Market updated = marketService.updateTag(marketId, "new tag");
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getTag()).isEqualTo("new tag");
+        }
+    }
+
+    @Nested
+    @DisplayName("Update State")
+    class UpdateState {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(market)).when(marketRepository).findById(marketId);
+            MarketArticleState newState = MarketArticleState.RESERVED;
+
+            // when
+            Market updated = marketService.updateState(marketId, newState);
+
+            // then
+            assertThat(updated).isNotNull();
+            assertThat(updated.getState()).isEqualTo(newState);
+        }
+    }
+
+    @Nested
+    @DisplayName("Delete Market")
+    class DeleteMarket {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(market)).when(marketRepository).findById(marketId);
+
+            // when
+            marketService.delete(marketId);
+
+            // then
+            verify(marketRepository).delete(market);
+            verify(articleRepository).delete(article);
+        }
+
+        @Test
+        void fail_NotFoundArticle() {
+            // given
+            doReturn(Optional.empty()).when(marketRepository).findById(marketId);
+
+            // when
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> marketService.delete(marketId));
+
+            // then
+            assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_ARTICLE);
+
+        }
+    }
+}

--- a/src/test/java/com/charmroom/charmroom/service/SubscribeServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/SubscribeServiceUnitTest.java
@@ -1,0 +1,95 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Subscribe;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.repository.SubscribeRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class SubscribeServiceUnitTest {
+    @Mock
+    SubscribeRepository subscribeRepository;
+    @Mock
+    UserRepository userRepository;
+    @InjectMocks
+    SubscribeService subscribeService;
+
+    private Subscribe subscribe;
+    private User target;
+    private User subscriber;
+
+    User createUser(String prefix) {
+        return User.builder()
+                .username(prefix + "username")
+                .nickname("nickname")
+                .email("email@example.com")
+                .build();
+    }
+
+    Subscribe createSubscribe() {
+        return Subscribe.builder()
+                .subscriber(subscriber)
+                .target(target)
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        target = createUser("target");
+        subscriber = createUser("subscriber");
+        subscribe = createSubscribe();
+    }
+
+    @Nested
+    @DisplayName("create Subscribe")
+    class CreateSubscribe {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(target)).when(userRepository).findByUsername(target.getUsername());
+            doReturn(Optional.of(subscriber)).when(userRepository).findByUsername(subscriber.getUsername());
+
+            doReturn(Optional.empty()).when(subscribeRepository).findBySubscriberAndTarget(subscriber, target);
+            doReturn(subscribe).when(subscribeRepository).save(any(Subscribe.class));
+
+            // when
+            Subscribe created =  subscribeService.create(subscriber.getUsername(), target.getUsername());
+
+            // then
+            assertThat(created).isNotNull();
+            assertThat(created.getSubscriber()).isEqualTo(subscriber);
+        }
+
+        @Test
+        void whenExistingSubscribe() {
+            // given
+            doReturn(Optional.of(target)).when(userRepository).findByUsername(target.getUsername());
+            doReturn(Optional.of(subscriber)).when(userRepository).findByUsername(subscriber.getUsername());
+
+            doReturn(Optional.of(subscribe)).when(subscribeRepository).findBySubscriberAndTarget(subscriber, target);
+
+            // when
+            Subscribe result = subscribeService.create(subscriber.getUsername(), target.getUsername());
+
+            // then
+            assertNull(result);
+            verify(subscribeRepository).delete(any(Subscribe.class));
+        }
+    }
+}

--- a/src/test/java/com/charmroom/charmroom/service/WishServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/WishServiceUnitTest.java
@@ -1,0 +1,126 @@
+package com.charmroom.charmroom.service;
+
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.Market;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.Wish;
+import com.charmroom.charmroom.entity.enums.MarketArticleState;
+import com.charmroom.charmroom.repository.MarketRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+import com.charmroom.charmroom.repository.WishRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class WishServiceUnitTest {
+    @Mock
+    private WishRepository wishRepository;
+    @Mock
+    private MarketRepository marketRepository;
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private WishService wishService;
+
+    private Wish wish;
+    private Market market;
+    private Article article;
+    private User user;
+    private Board board;
+    private String username;
+    private Integer marketId;
+
+    User cresteUser() {
+        return User.builder()
+                .username(username)
+                .nickname("nickname")
+                .email("email@example.com")
+                .build();
+    }
+
+    Article createArticle() {
+        return Article.builder()
+                .title("title")
+                .body("body")
+                .user(user)
+                .board(board)
+                .build();
+    }
+
+    Market createMarket() {
+        return Market.builder()
+                .id(marketId)
+                .tag("")
+                .price(1000)
+                .state(MarketArticleState.SALE)
+                .article(article)
+                .build();
+    }
+
+    Wish createWish() {
+        return Wish.builder()
+                .market(market)
+                .user(user)
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        username = "username";
+        marketId = 1;
+        user = cresteUser();
+        article = createArticle();
+        market = createMarket();
+        wish = createWish();
+    }
+
+    @Nested
+    @DisplayName("Create Wish")
+    class CreateWish {
+        @Test
+        void success() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(username);
+            doReturn(Optional.of(market)).when(marketRepository).findById(marketId);
+            doReturn(wish).when(wishRepository).save(any(Wish.class));
+            doReturn(Optional.empty()).when(wishRepository).findByUserAndMarket(user, market);
+
+            // when
+            Wish created = wishService.create(username, marketId);
+
+            // then
+            assertThat(created).isNotNull();
+            assertThat(created.getUser()).isEqualTo(user);
+        }
+
+        @Test
+        void whenExistingWish() {
+            // given
+            doReturn(Optional.of(user)).when(userRepository).findByUsername(username);
+            doReturn(Optional.of(market)).when(marketRepository).findById(marketId);
+            doReturn(Optional.of(wish)).when(wishRepository).findByUserAndMarket(user, market);
+
+            // when
+            Wish created = wishService.create(username, marketId);
+
+            // then
+            verify(wishRepository).delete(any(Wish.class));
+            assertNull(created);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명
아래의 엔티티에 해당하는 Service 구현 및 단위 테스트 코드 작성하였습니다.
- Article
- ArticleLike
- Ad
- Market
- Wish
- Subscribe
- Club



## 참고(선택)
> 리뷰어가 참고할만한 내용

### 엔티티 변경
ArticleLike 변경사항
- changeType(Boolean) 추가
---
### 레포지토리 변경
ClubRepository 
- existsByName(String) 추가
- findByName(String) 추가
--- 
### 새롭게 알게 된 내용
Mockito 프레임워크를 사용하면서 테스트 코드를 작성하는 과정에서 알게 된 내용을 공유합니다. 


#### 1. Mockito와 Mock 관련 지식
- **doReturn().when()**
메서드 호출에 대한 반환값을 설정할 때 사용됩니다.
```
doReturn(expectedValue).when(mockObject).methodCall();
```
- **when().thenReturn()**
주로 메서드가 특정 값을 반환할 때 사용됩니다.
```
when(mockObject.method()).thenReturn(expectedValue);
```
- **doReturn().when() 과 when().thenReturn()의 차이**
  -  메서드 호출 시점의 차이
      - when().thenReturn(): 메서드가 실제로 호출되는 시점에서 stubbing이 적용됩니다. 메서드 호출 시 예외가 발생할 수 있습니다.
      - doReturn().when(): stubbing 설정 시 메서드가 실제로 호출되지 않습니다. 때문에 메서드 호출로 인한 예외가 발생하지 않습니다.
  - void 메서드와의 호환성
    -  when().thenReturn(): void 메서드에 stubbing 하지 못해 예외가 발생합니다.
    -  doReturn().when(): void 메서드에 사용할 수 있습니다. (doNothing() 메서드 지원)
  - 메서드 호출 체인에서의 차이
    - when().thenReturn(): 메서드가 호출될 때 stubbing이 적용되기 때문에 메서드 체인을 사용하는 경우, 예외가 발생할 수 있습니다. 예를 들어, 첫 번째 메서드가 null 반환 시 다음 메서드 호출 시 문제가 될 수 있습니다.
    - doReturn().when(): 메서드 체인 사용 시 중간에 null 이 반환되더라도 안전하게 사용할 수 있습니다. 
- @Mock
이 어노테이션을 통해 Mock 객체를 생성할 수 있어, 실제 객체를 사용하지 않고 테스트를 할 수 있게 해줍니다.
- @InjectMocks
이 어노테이션을 통해 Mock 객체를 주입해 실제로 테스트할 객체를 만드는 데 사용됩니다. 


#### 2. Unnecessary Stubbing Exception
- Unnecessary Stubbing Exception이란?
Mockito에서 불필요한 stubbing이 감지되었을 때 발생하는 예외입니다. 즉, 테스트 코드에서 설정한 stubbing이 실제로 사용되지 않는 경우에 발생합니다.

이 예외를 통해 테스트 코드에서 사용되지 않는 불필요한 stub을 줄일 수 있고, 테스트코드가 깨끗해집니다.

- 해결 방법
  - 불필요한 stubbing 제거하기
  - lenient  모드 사용하기(권장 X)

---

### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)
Resolces: #36 

