### PR TITLE
[✨ Feature] #41 CharmroomUtil 수정, 서비스 코드 수정 

### DIFF
--- a/src/main/java/com/charmroom/charmroom/entity/Article.java
+++ b/src/main/java/com/charmroom/charmroom/entity/Article.java
@@ -1,6 +1,7 @@
 package com.charmroom.charmroom.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -54,8 +55,9 @@ public class Article {
     @OneToMany(mappedBy = "article")
     private List<Comment> commentList;
     
+    @Builder.Default
     @OneToMany(mappedBy = "article")
-    private List<Attachment> attachmentList;
+    private List<Attachment> attachmentList = new ArrayList<>();
 
     public void updateTitle(String title) {
         this.title = title;

--- a/src/main/java/com/charmroom/charmroom/service/ArticleService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ArticleService.java
@@ -1,5 +1,13 @@
 package com.charmroom.charmroom.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.charmroom.charmroom.entity.Article;
 import com.charmroom.charmroom.entity.Attachment;
 import com.charmroom.charmroom.entity.Board;
@@ -9,15 +17,8 @@ import com.charmroom.charmroom.exception.BusinessLogicException;
 import com.charmroom.charmroom.repository.ArticleRepository;
 import com.charmroom.charmroom.repository.AttachmentRepository;
 import com.charmroom.charmroom.util.CharmroomUtil;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -27,22 +28,22 @@ public class ArticleService {
     private final CharmroomUtil.Upload uploadUtil;
 
     public Article createArticle(User user, Board board, String title, String body, List<MultipartFile> fileList) {
-        List<Attachment> attachmentList = new ArrayList<>();
-
-        for (MultipartFile attachment : fileList) {
-            Attachment attachmentEntity = uploadUtil.buildAttachment(attachment);
-            Attachment saved = attachmentRepository.save(attachmentEntity);
-            attachmentList.add(saved);
-        }
+        
 
         Article article = Article.builder()
                 .title(title)
                 .body(body)
                 .user(user)
                 .board(board)
-                .attachmentList(attachmentList)
                 .build();
 
+
+        for (MultipartFile attachment : fileList) {
+            Attachment attachmentEntity = uploadUtil.buildAttachment(attachment, article);
+            Attachment saved = attachmentRepository.save(attachmentEntity);
+            article.getAttachmentList().add(saved);
+        }
+        
         return articleRepository.save(article);
     }
 

--- a/src/main/java/com/charmroom/charmroom/util/CharmroomUtil.java
+++ b/src/main/java/com/charmroom/charmroom/util/CharmroomUtil.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.charmroom.charmroom.entity.Article;
 import com.charmroom.charmroom.entity.Attachment;
 import com.charmroom.charmroom.entity.Image;
 import com.charmroom.charmroom.entity.enums.AttachmentType;
@@ -51,7 +52,7 @@ public class CharmroomUtil {
 					.build();
 		}
 		
-		public Attachment buildAttachment(MultipartFile attachment) {
+		public Attachment buildAttachment(MultipartFile attachment, Article article) {
 			String originalName = attachment.getOriginalFilename();
 			String fullPath = newFileName(attachmentUploadPath, attachment);
 			uploadFile(fullPath, attachment);
@@ -62,6 +63,7 @@ public class CharmroomUtil {
 				type = AttachmentType.VIDEO;
 			
 			return Attachment.builder()
+					.article(article)
 					.path(fullPath)
 					.originalName(originalName)
 					.type(type)

--- a/src/test/java/com/charmroom/charmroom/service/ArticleServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ArticleServiceUnitTest.java
@@ -1,16 +1,16 @@
 package com.charmroom.charmroom.service;
 
-import com.charmroom.charmroom.entity.Article;
-import com.charmroom.charmroom.entity.Attachment;
-import com.charmroom.charmroom.entity.Board;
-import com.charmroom.charmroom.entity.User;
-import com.charmroom.charmroom.entity.enums.AttachmentType;
-import com.charmroom.charmroom.entity.enums.BoardType;
-import com.charmroom.charmroom.exception.BusinessLogicError;
-import com.charmroom.charmroom.exception.BusinessLogicException;
-import com.charmroom.charmroom.repository.ArticleRepository;
-import com.charmroom.charmroom.repository.AttachmentRepository;
-import com.charmroom.charmroom.util.CharmroomUtil;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,15 +29,17 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Attachment;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.enums.AttachmentType;
+import com.charmroom.charmroom.entity.enums.BoardType;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.AttachmentRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
 
 @ExtendWith(MockitoExtension.class)
 public class ArticleServiceUnitTest {
@@ -135,9 +137,9 @@ public class ArticleServiceUnitTest {
         @Test
         void success() {
             // given
-            doReturn(attachment1).when(uploadUtil).buildAttachment(multipartFile1);
-            doReturn(attachment2).when(uploadUtil).buildAttachment(multipartFile2);
-            doReturn(attachment3).when(uploadUtil).buildAttachment(multipartFile3);
+            doReturn(attachment1).when(uploadUtil).buildAttachment(eq(multipartFile1), any(Article.class));
+            doReturn(attachment2).when(uploadUtil).buildAttachment(eq(multipartFile2), any(Article.class));
+            doReturn(attachment3).when(uploadUtil).buildAttachment(eq(multipartFile3), any(Article.class));
             doReturn(attachment1).when(attachmentRepository).save(attachment1);
             doReturn(attachment2).when(attachmentRepository).save(attachment2);
             doReturn(attachment3).when(attachmentRepository).save(attachment3);

--- a/src/test/java/com/charmroom/charmroom/service/ClubServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ClubServiceUnitTest.java
@@ -1,14 +1,14 @@
 package com.charmroom.charmroom.service;
 
-import com.charmroom.charmroom.entity.Club;
-import com.charmroom.charmroom.entity.Image;
-import com.charmroom.charmroom.entity.User;
-import com.charmroom.charmroom.exception.BusinessLogicError;
-import com.charmroom.charmroom.exception.BusinessLogicException;
-import com.charmroom.charmroom.repository.ClubRepository;
-import com.charmroom.charmroom.repository.ImageRepository;
-import com.charmroom.charmroom.repository.UserRepository;
-import com.charmroom.charmroom.util.CharmroomUtil;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,14 +23,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
+import com.charmroom.charmroom.entity.Club;
+import com.charmroom.charmroom.entity.Image;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.repository.ClubRepository;
+import com.charmroom.charmroom.repository.ImageRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
 
 @ExtendWith(MockitoExtension.class)
 public class ClubServiceUnitTest {
@@ -50,15 +50,7 @@ public class ClubServiceUnitTest {
     private String description;
     private String contact;
     private int clubId;
-    private String username;
-    private User user;
-
-    private User createUser(String prefix) {
-        return User.builder()
-                .username(prefix + username)
-                .build();
-    }
-
+    
     private Club createClub(String prefix) {
         return Club.builder()
                 .id(clubId)
@@ -75,7 +67,6 @@ public class ClubServiceUnitTest {
         description = "club description";
         contact = "club contact";
         club = createClub("");
-        user = createUser("");
     }
 
     @Nested

--- a/src/test/java/com/charmroom/charmroom/util/CharmroomUtilTest.java
+++ b/src/test/java/com/charmroom/charmroom/util/CharmroomUtilTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.TestPropertySource;
 
+import com.charmroom.charmroom.entity.Article;
 import com.charmroom.charmroom.entity.Attachment;
 import com.charmroom.charmroom.entity.Image;
 import com.charmroom.charmroom.entity.enums.AttachmentType;
@@ -109,10 +110,12 @@ public class CharmroomUtilTest {
 				MockMultipartFile imageFile = new MockMultipartFile("file", "test1.png", "image/png", "test".getBytes());
 				MockMultipartFile videoFile = new MockMultipartFile("file", "test2.mp4", "video/mp4", "test".getBytes());
 				MockMultipartFile etcFile = new MockMultipartFile("file", "test3.html", "text/html", "test".getBytes());
+				Article article = Article.builder()
+						.build();
 				// when
-				Attachment image = uploadUtil.buildAttachment(imageFile);
-				Attachment video = uploadUtil.buildAttachment(videoFile);
-				Attachment etc = uploadUtil.buildAttachment(etcFile);
+				Attachment image = uploadUtil.buildAttachment(imageFile, article);
+				Attachment video = uploadUtil.buildAttachment(videoFile, article);
+				Attachment etc = uploadUtil.buildAttachment(etcFile, article);
 				
 				// then
 				assertThat(image).isNotNull();
@@ -147,7 +150,9 @@ public class CharmroomUtilTest {
 				MockMultipartFile attachmentFile = new MockMultipartFile("file", "test3.html", "text/html", "test".getBytes());
 				
 				Image image = uploadUtil.buildImage(imageFile);
-				Attachment attachment = uploadUtil.buildAttachment(attachmentFile);
+				Article article = Article.builder()
+						.build();
+				Attachment attachment = uploadUtil.buildAttachment(attachmentFile, article);
 				
 				// when
 				uploadUtil.deleteImageFile(image);


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명

- Charmroom Util 첨부파일 생성시 article과 연결 문제 해결
  - CharmroomUtil의 첨부파일 생성 함수 원형이 다음과 같이 수정됨
  ```Java
  public Attachment buildAttachment(MultipartFile attachment, Article article)
  ```
- UserService의 기능 중 유저 생성 시 이미지 등록과 이미지 수정 필요
  - 다음 두 가지 원형의 함수 중 하나를 선택하여 사용 가능
  ```Java
  public User create(String username, String email, String nickname, String password, MultipartFile imageFile)
  public User create(String username, String email, String nickname, String password)
  ```
  - 이미지 수정 시 기존 파일이 삭제되도록 변경 완료
- 그 외의 서비스 코드 중에 오류를 발생시킬 수 있는 코드에 대한 수정 (ArticleService)
## 참고(선택)
> 리뷰어가 참고할만한 내용



### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)

참고: #48, #46 
Resolves #41 

