### PR TITLE
Test/#97 Auth 컨트롤러 통합 테스트

### DIFF
--- a/src/main/java/com/charmroom/charmroom/controller/api/AdminController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/AdminController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/charmroom/charmroom/dto/business/CommentMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/CommentMapper.java
@@ -1,8 +1,5 @@
 package com.charmroom.charmroom.dto.business;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.charmroom.charmroom.dto.presentation.CommentDto.CommentResponseDto;
 import com.charmroom.charmroom.entity.Comment;
 

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
@@ -7,10 +7,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.tomcat.util.http.fileupload.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
@@ -20,6 +27,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.charmroom.charmroom.util.CharmroomUtil;
+
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
@@ -27,12 +36,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthControllerIntegrationTestDy {
 	@Autowired
 	MockMvc mockMvc;
+	@Autowired
+	CharmroomUtil.Upload upload;
 	
 	MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
 	String username = "test";
 	String password = "password";
 	String email = "test@test.com";
 	String nickname = "nickname";
+	
+	@AfterAll
+	static void cleanUp(
+			@Value("${charmroom.upload.image.path}") String imageUploadPath,
+			@Value("${charmroom.upload.attachment.path}") String attachmentUploadPath) throws IOException {
+		FileUtils.cleanDirectory(new File(imageUploadPath));
+		FileUtils.cleanDirectory(new File(attachmentUploadPath));
+	}
+	
 	
 	@Nested
 	class Signup {

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
@@ -1,0 +1,269 @@
+package com.charmroom.charmroom.controller.integration;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+public class AuthControllerIntegrationTestDy {
+	@Autowired
+	MockMvc mockMvc;
+	
+	MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
+	String username = "test";
+	String password = "password";
+	String email = "test@test.com";
+	String nickname = "nickname";
+	
+	@Nested
+	class Signup {
+		String url = "/api/auth/signup";
+		@Test
+		void success() throws Exception {
+			// given
+			
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isCreated()
+					,jsonPath("$.code").value("CREATED")
+					,jsonPath("$.data.username").value(username)
+					,jsonPath("$.data.nickname").value(nickname)
+					,jsonPath("$.data.email").value(email)
+					)
+			;
+		}
+		@Test
+		void successWithoutImage() throws Exception {
+			// given
+			// when
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isCreated()
+					,jsonPath("$.code").value("CREATED")
+					,jsonPath("$.data.username").value(username)
+					,jsonPath("$.data.nickname").value(nickname)
+					,jsonPath("$.data.email").value(email)
+					)
+			;
+		}
+		@Test
+		void failPasswordValidation() throws Exception{
+			// given
+			// when
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", "1234")
+					.param("rePassword", "5678")
+					.param("email", email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.signupRequestDto", containsString("password"))
+					)
+			;
+		}
+		
+		@Test
+		void failDuplicatedUsername() throws Exception {
+			// given
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+			
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", "a" + email)
+					.param("nickname", "a" + nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.username", containsString("Duplicated"))
+					)
+			;
+		}
+		
+		@Test
+		void failDuplicatedEmail() throws Exception {
+			// given
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+			
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", "a" + username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", "a" + nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.email", containsString("Duplicated"))
+					)
+			;
+		}
+		
+		@Test
+		void failDuplicatedNickname() throws Exception{
+			// given
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", "a" + username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", "a" +  email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.nickname", containsString("Duplicated"))
+					)
+			;
+		}
+		
+		@Test
+		void failMultipleValidationError() throws Exception{
+			// given
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", username)
+					.param("password", "1234")
+					.param("rePassword", "5678")
+					.param("email", email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.signupRequestDto", containsString("password"))
+					,jsonPath("$.data.username", containsString("Duplicated"))
+					,jsonPath("$.data.email", containsString("Duplicated"))
+					,jsonPath("$.data.nickname", containsString("Duplicated"))
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class Login {
+		String url = "/api/auth/login";
+		
+		@BeforeEach
+		void setup() throws Exception {
+			// given
+			mockMvc.perform(multipart("/api/auth/signup")
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+		}
+		
+		@Test
+		void success() throws Exception {
+			// when
+			mockMvc.perform(post(url)
+					.param("username", username)
+					.param("password", password)
+					)
+			// then
+			.andExpectAll(
+					status().isOk()
+					,header().exists(HttpHeaders.AUTHORIZATION)
+					)
+			;
+		}
+		
+		@Test
+		void fail() throws Exception {
+			// when
+			mockMvc.perform(post(url)
+					.param("username", username)
+					.param("password", password + "1")
+					)
+			// then
+			.andExpect(
+					status().isUnauthorized()
+					)
+			;
+		}
+	}
+	
+	
+}


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명

Auth 컨트롤러 통합 테스트 코드 작성 완료

## 참고(선택)
> 리뷰어가 참고할만한 내용

이미지 또는 첨부파일을 업로드 하는 테스트 코드 작성 시 아래 AfterAll 함수를 추가해주면 테스트 후 불필요한 리소스를 삭제할 수 있다.
```Java
@AfterAll
static void cleanUp(
	@Value("${charmroom.upload.image.path}") String imageUploadPath,
	@Value("${charmroom.upload.attachment.path}") String attachmentUploadPath) throws IOException {
    FileUtils.cleanDirectory(new File(imageUploadPath));
    FileUtils.cleanDirectory(new File(attachmentUploadPath));
}
```

### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)
Resolves #97 
참고 #96 

