### PR TITLE
Test/#99 user

### DIFF
--- a/src/main/java/com/charmroom/charmroom/controller/api/UserController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/UserController.java
@@ -21,6 +21,7 @@ import com.charmroom.charmroom.service.CommentService;
 import com.charmroom.charmroom.service.PointService;
 import com.charmroom.charmroom.service.UserService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -41,7 +42,7 @@ public class UserController {
 	@PatchMapping("")
 	public ResponseEntity<?> updateMyInfo(
 			@AuthenticationPrincipal User user,
-			@RequestBody UserUpdateRequest request){
+			@RequestBody @Valid UserUpdateRequest request){
 		var dto = userService.changeNickname(user.getUsername(), request.getNickname());
 		var response = UserMapper.toResponse(dto);
 		return CommonResponseDto.ok(response).toResponseEntity();

--- a/src/main/java/com/charmroom/charmroom/dto/business/ArticleMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/ArticleMapper.java
@@ -6,9 +6,10 @@ import java.util.List;
 import com.charmroom.charmroom.dto.presentation.ArticleDto.ArticleResponseDto;
 import com.charmroom.charmroom.entity.Article;
 
-public class ArticleMapper {
+import io.jsonwebtoken.lang.Arrays;
 
-	public static ArticleDto toDto(Article entity) {
+public class ArticleMapper {
+	public static ArticleDto toDto(Article entity, String... ignore) {
 		ArticleDto dto = ArticleDto.builder()
 				.id(entity.getId())
 				.title(entity.getTitle())
@@ -17,28 +18,27 @@ public class ArticleMapper {
 				.updatedAt(entity.getUpdatedAt())
 				.view(entity.getView())
 				.build();
-		if (entity.getUser() != null) {
+		List<String> ignores = Arrays.asList(ignore);
+		if (entity.getUser() != null && !ignores.contains("user")) {
 			dto.setUser(UserMapper.toDto(entity.getUser()));
 		}
-		if (entity.getBoard() != null) {
+		if (entity.getBoard() != null && !ignores.contains("board")) {
 			dto.setBoard(BoardMapper.toDto(entity.getBoard()));
 		}
-		if (entity.getCommentList().size() > 0) {
+		if (entity.getCommentList().size() > 0 && !ignores.contains("commentList")) {
 			var commentList = entity.getCommentList();
 			List<CommentDto> commentDtoList = new ArrayList<>();
 			for(var comment : commentList) {
-				CommentDto commentDto = CommentMapper.toDto(comment);
-				commentDto.setArticle(null);
+				CommentDto commentDto = CommentMapper.toDto(comment, "article");
 				commentDtoList.add(commentDto);
 			}
 			dto.setCommentList(commentDtoList);
 		}
-		if (entity.getAttachmentList().size() > 0) {
+		if (entity.getAttachmentList().size() > 0 && !ignores.contains("attachmentList")) {
 			var attachmentList = entity.getAttachmentList();
 			List<AttachmentDto> attachmentDtoList = new ArrayList<>();
 			for(var attachment : attachmentList) {
-				AttachmentDto attachmentDto = AttachmentMapper.toDto(attachment);
-				attachmentDto.setArticle(null);
+				AttachmentDto attachmentDto = AttachmentMapper.toDto(attachment, "article");
 				attachmentDtoList.add(attachmentDto);
 			}
 			dto.setAttachmentList(attachmentDtoList);
@@ -51,5 +51,4 @@ public class ArticleMapper {
 				.id(dto.getId())
 				.build();
 	}
-
 }

--- a/src/main/java/com/charmroom/charmroom/dto/business/AttachmentMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/AttachmentMapper.java
@@ -1,18 +1,22 @@
 package com.charmroom.charmroom.dto.business;
 
+import java.util.List;
+
 import com.charmroom.charmroom.entity.Attachment;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class AttachmentMapper {
-	public static AttachmentDto toDto(Attachment entity) {
+	public static AttachmentDto toDto(Attachment entity, String... ignore) {
 		AttachmentDto dto = AttachmentDto.builder()
 				.id(entity.getId())
 				.type(entity.getType())
 				.path(entity.getPath())
 				.originalName(entity.getOriginalName())
 				.build();
-		if (entity.getArticle() != null) {
-			ArticleDto articleDto = ArticleMapper.toDto(entity.getArticle());
-			articleDto.setAttachmentList(null);
+		List<String> ignores = Arrays.asList(ignore);
+		if (entity.getArticle() != null && !ignores.contains("article")) {
+			ArticleDto articleDto = ArticleMapper.toDto(entity.getArticle(), "attachmentList");
 			dto.setArticle(articleDto);
 		}
 		return dto;

--- a/src/main/java/com/charmroom/charmroom/dto/business/ClubMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/ClubMapper.java
@@ -6,10 +6,12 @@ import java.util.List;
 import com.charmroom.charmroom.entity.Club;
 import com.charmroom.charmroom.entity.User;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class ClubMapper {
-	public static ClubDto toDto(Club entity) {
+	public static ClubDto toDto(Club entity, String... ignore) {
 		if (entity == null) return null;
-		
+		var ignores = Arrays.asList(ignore);
 		ClubDto dto =  ClubDto.builder()
 				.id(entity.getId())
 				.name(entity.getName())
@@ -18,12 +20,11 @@ public class ClubMapper {
 				.image(ImageMapper.toDto(entity.getImage()))
 				.build();
 		
-		if (entity.getUserList().size() > 0) {
+		if (entity.getUserList().size() > 0 && !ignores.contains("userList")) {
 			List<User> userList = entity.getUserList();
 			List<UserDto> userDtoList = new ArrayList<>();
 			for (User user : userList) {
-				UserDto userDto = UserMapper.toDto(user);
-				userDto.setClub(null);
+				UserDto userDto = UserMapper.toDto(user, "club");
 				userDtoList.add(userDto);
 			}
 			dto.setUserList(userDtoList);

--- a/src/main/java/com/charmroom/charmroom/dto/business/CommentMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/CommentMapper.java
@@ -1,10 +1,15 @@
 package com.charmroom.charmroom.dto.business;
 
+import java.util.List;
+
 import com.charmroom.charmroom.dto.presentation.CommentDto.CommentResponseDto;
 import com.charmroom.charmroom.entity.Comment;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class CommentMapper {
-	public static CommentDto toDto(Comment entity) {
+	
+	public static CommentDto toDto(Comment entity, String... ignore) {
 		CommentDto dto = CommentDto.builder()
 				.id(entity.getId())
 				.body(entity.getBody())
@@ -12,27 +17,26 @@ public class CommentMapper {
 				.updatedAt(entity.getUpdatedAt())
 				.disabled(entity.isDisabled())
 				.build();
-		if (entity.getUser() != null) {
+		List<String> ignores = Arrays.asList(ignore);
+		if (entity.getUser() != null && !ignores.contains("user")) {
 			UserDto userDto = UserMapper.toDto(entity.getUser());
 			dto.setUser(userDto);
 		}
-		if (entity.getArticle() != null) {
-			ArticleDto articleDto = ArticleMapper.toDto(entity.getArticle());
-			articleDto.setCommentList(null);
+		if (entity.getArticle() != null && !ignores.contains("article")) {
+			ArticleDto articleDto = ArticleMapper.toDto(entity.getArticle(), "commentList");
 			dto.setArticle(articleDto);
 		}
-		if (entity.getParent() != null) {
-			CommentDto parent = CommentMapper.toDto(entity.getParent());
-			parent.setChildList(null);
+		if (entity.getParent() != null && !ignores.contains("parent")) {
+			CommentDto parent = CommentMapper.toDto(entity.getParent(), "childList");
 			dto.setParent(parent);
 		}
 		
-		for(var child : entity.getChildList()) {
-			CommentDto childDto = CommentMapper.toDto(child);
-			childDto.setParent(null);
-			dto.getChildList().add(childDto);
+		if (!ignores.contains("childList")) {
+			for(var child : entity.getChildList()) {
+				CommentDto childDto = CommentMapper.toDto(child, "parent");
+				dto.getChildList().add(childDto);
+			}
 		}
-		
 		
 		Integer like = 0, dislike = 0;
 		for(var cl : entity.getCommentLike()) {
@@ -47,6 +51,7 @@ public class CommentMapper {
 		return dto;
 	}
 
+	
 	public static CommentResponseDto toResponse(CommentDto dto) {
 		var response = CommentResponseDto.builder()
 				.id(dto.getId())
@@ -63,10 +68,17 @@ public class CommentMapper {
 			response.setUser(UserMapper.toResponse(dto.getUser()));
 		if (dto.getArticle() != null)
 			response.setArticleId(dto.getArticle().getId());
-		if (dto.getParent() != null)
-			response.setParentId(dto.getParent().getId());
+		if (dto.getParent() != null) {
+			var parent = toResponse(dto.getParent());
+			parent.getChildList().clear();
+			response.setParent(parent);
+		}
 		if (dto.getChildList().size() > 0) {
-			var childList = dto.getChildList().stream().map(child -> toResponse(child)).toList();
+			var childList = dto.getChildList().stream()
+					.map(child -> toResponse(child))
+					.toList()
+					;
+			childList.forEach(child -> child.setParent(null));
 			response.setChildList(childList);
 		}
 		

--- a/src/main/java/com/charmroom/charmroom/dto/business/ImageMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/ImageMapper.java
@@ -15,6 +15,8 @@ public class ImageMapper {
 	}
 	
 	public static ImageResponseDto toResponse(ImageDto dto) {
+		if (dto == null) return null;
+		
 		return ImageResponseDto.builder()
 				.id(dto.getId())
 				.originalName(dto.getOriginalName())

--- a/src/main/java/com/charmroom/charmroom/dto/business/PointMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/PointMapper.java
@@ -1,12 +1,16 @@
 package com.charmroom.charmroom.dto.business;
 
+import java.util.List;
+
 import com.charmroom.charmroom.dto.presentation.PointDto.PointResponseDto;
 import com.charmroom.charmroom.entity.Point;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class PointMapper {
-	public static PointDto toDto(Point entity) {
+	public static PointDto toDto(Point entity, String... ignore) {
 		if (entity == null) return null;
-		
+		List<String> ignores = Arrays.asList(ignore);
 		PointDto dto =  PointDto.builder()
 				.id(entity.getId())
 				.updatedAt(entity.getUpdatedAt())
@@ -14,9 +18,8 @@ public class PointMapper {
 				.diff(entity.getDiff())
 				.build();
 		
-		if (entity.getUser() != null) {
-			UserDto user = UserMapper.toDto(entity.getUser());
-			user.setPointList(null);
+		if (entity.getUser() != null && !ignores.contains("user")) {
+			UserDto user = UserMapper.toDto(entity.getUser(), "pointList");
 			dto.setUser(user);
 		}
 		return dto;

--- a/src/main/java/com/charmroom/charmroom/dto/business/UserMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/UserMapper.java
@@ -7,8 +7,10 @@ import com.charmroom.charmroom.dto.presentation.UserDto.UserResponseDto;
 import com.charmroom.charmroom.entity.Point;
 import com.charmroom.charmroom.entity.User;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class UserMapper {
-	public static UserDto toDto(User entity) {
+	public static UserDto toDto(User entity, String... ignore) {
 		if (entity == null) return null;
 		UserDto dto = UserDto.builder()
 				.id(entity.getId())
@@ -19,21 +21,20 @@ public class UserMapper {
 				.withdraw(entity.isWithdraw())
 				.level(entity.getLevel())
 				.build();
-		
-		if (entity.getImage() != null) {
+		List<String> ignores = Arrays.asList(ignore);
+		if (entity.getImage() != null && !ignores.contains("image")) {
 			dto.setImage(ImageMapper.toDto(entity.getImage()));
 		}
-		if (entity.getClub() != null) {
-			ClubDto club = ClubMapper.toDto(entity.getClub());
+		if (entity.getClub() != null && !ignores.contains("club")) {
+			ClubDto club = ClubMapper.toDto(entity.getClub(), "userList");
 			club.setUserList(null);
 			dto.setClub(club);
 		}
-		if (entity.getPointList().size() > 0) {
+		if (entity.getPointList().size() > 0 && !ignores.contains("pointList")) {
 			List<Point> pointList = entity.getPointList();
 			List<PointDto> pointDtoList = new ArrayList<>();
 			for(Point point : pointList) {
-				PointDto pointDto = PointMapper.toDto(point);
-				pointDto.setUser(null);
+				PointDto pointDto = PointMapper.toDto(point, "user");
 				pointDtoList.add(pointDto);
 			}
 			dto.setPointList(pointDtoList);
@@ -48,6 +49,7 @@ public class UserMapper {
 				.nickname(dto.getNickname())
 				.withdraw(dto.isWithdraw())
 				.level(dto.getLevel().getValue())
+				.image(ImageMapper.toResponse(dto.getImage()))
 				.build();
 	}
 }

--- a/src/main/java/com/charmroom/charmroom/dto/presentation/CommentDto.java
+++ b/src/main/java/com/charmroom/charmroom/dto/presentation/CommentDto.java
@@ -37,7 +37,7 @@ public class CommentDto {
 		private Integer id;
 		private UserResponseDto user;
 		private Integer articleId;
-		private Integer parentId;
+		private CommentResponseDto parent;
 		@Builder.Default
 		private List<CommentResponseDto> childList = new ArrayList<>();
 		private String body;

--- a/src/main/java/com/charmroom/charmroom/dto/presentation/UserDto.java
+++ b/src/main/java/com/charmroom/charmroom/dto/presentation/UserDto.java
@@ -52,6 +52,9 @@ public class UserDto {
 	@NoArgsConstructor
 	@Builder
 	public static class UserUpdateRequest{
+		@Size(min = 3, max = 30)
+		@NotEmpty
+		@ValidUser.Unique.Nickname
 		private String nickname;
 	}
 	

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AdminControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AdminControllerIntegrationTestDy.java
@@ -1,0 +1,10 @@
+package com.charmroom.charmroom.controller.integration;
+
+import org.junit.jupiter.api.Nested;
+
+public class AdminControllerIntegrationTestDy extends IntegrationTestBase {
+	@Nested
+	class Users{
+		
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 
 import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,8 +26,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.charmroom.charmroom.util.CharmroomUtil;
-
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
@@ -36,8 +33,6 @@ import com.charmroom.charmroom.util.CharmroomUtil;
 public class AuthControllerIntegrationTestDy {
 	@Autowired
 	MockMvc mockMvc;
-	@Autowired
-	CharmroomUtil.Upload upload;
 	
 	MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
 	String username = "test";

--- a/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
@@ -36,7 +36,7 @@ import com.google.gson.Gson;
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@Transactional(propagation = Propagation.SUPPORTS)
+@Transactional
 public class IntegrationTestBase {
 	@Autowired
 	MockMvc mockMvc;

--- a/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
@@ -1,0 +1,85 @@
+package com.charmroom.charmroom.controller.integration;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apache.tomcat.util.http.fileupload.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.enums.UserLevel;
+import com.charmroom.charmroom.repository.UserRepository;
+
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+public class IntegrationTestBase {
+	@Autowired
+	MockMvc mockMvc;
+	
+	@Autowired
+	UserRepository userRepository;
+	
+	User charmroomUser;
+	User charmroomAdmin;
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@Inherited
+	@WithUserDetails(
+			value = "test", 
+			setupBefore = TestExecutionEvent.TEST_EXECUTION,
+			userDetailsServiceBeanName = "customUserDetailsService") 
+	@interface WithCharmroomUserDetails {}
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@Inherited
+	@WithUserDetails(
+			value = "admin", 
+			setupBefore = TestExecutionEvent.TEST_EXECUTION,
+			userDetailsServiceBeanName = "customUserDetailsService")
+	@interface WithCharmroomAdminDetails{}
+	
+	@AfterAll
+	static void cleanUp(
+			@Value("${charmroom.upload.image.path}") String imageUploadPath,
+			@Value("${charmroom.upload.attachment.path}") String attachmentUploadPath) throws IOException {
+		FileUtils.cleanDirectory(new File(imageUploadPath));
+		FileUtils.cleanDirectory(new File(attachmentUploadPath));
+	}
+	
+	@BeforeEach
+	void setup() throws Exception {
+		charmroomUser = User.builder()
+				.username("test")
+				.password("")
+				.email("test@test.com")
+				.nickname("test")
+				.level(UserLevel.ROLE_BASIC)
+				.build();
+		charmroomUser = userRepository.save(charmroomUser);
+		charmroomAdmin = User.builder()
+				.username("admin")
+				.password("")
+				.email("admin@admin.com")
+				.nickname("admin")
+				.level(UserLevel.ROLE_ADMIN)
+				.build();
+		charmroomAdmin = userRepository.save(charmroomAdmin);
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
@@ -15,26 +15,40 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.charmroom.charmroom.entity.Image;
 import com.charmroom.charmroom.entity.User;
 import com.charmroom.charmroom.entity.enums.UserLevel;
+import com.charmroom.charmroom.repository.ImageRepository;
 import com.charmroom.charmroom.repository.UserRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+import com.google.gson.Gson;
 
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@Transactional
+@Transactional(propagation = Propagation.SUPPORTS)
 public class IntegrationTestBase {
 	@Autowired
 	MockMvc mockMvc;
+	Gson gson;
 	
 	@Autowired
-	UserRepository userRepository;
+	private UserRepository userRepository;
+	@Autowired
+	private ImageRepository imageRepository;
+	
+	@Autowired
+	private CharmroomUtil.Upload uploadUtil;
 	
 	User charmroomUser;
 	User charmroomAdmin;
@@ -65,12 +79,19 @@ public class IntegrationTestBase {
 	
 	@BeforeEach
 	void setup() throws Exception {
+		MultipartFile file = new MockMultipartFile("image", "profile.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
+		Image profile1 = uploadUtil.buildImage(file);
+		Image profile2 = uploadUtil.buildImage(file);
+		profile1 = imageRepository.save(profile1);
+		profile2 = imageRepository.save(profile2);
+		
 		charmroomUser = User.builder()
 				.username("test")
 				.password("")
 				.email("test@test.com")
 				.nickname("test")
 				.level(UserLevel.ROLE_BASIC)
+				.image(profile1)
 				.build();
 		charmroomUser = userRepository.save(charmroomUser);
 		charmroomAdmin = User.builder()
@@ -79,7 +100,9 @@ public class IntegrationTestBase {
 				.email("admin@admin.com")
 				.nickname("admin")
 				.level(UserLevel.ROLE_ADMIN)
+				.image(profile2)
 				.build();
 		charmroomAdmin = userRepository.save(charmroomAdmin);
+		gson = new Gson();
 	}
 }

--- a/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
@@ -1,0 +1,37 @@
+package com.charmroom.charmroom.controller.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+public class UserControllerIntegrationTestDy extends IntegrationTestBase {
+	
+	
+	@Nested
+	class GetMyInfo{
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception {
+			mockMvc.perform(get("/api/user"))
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.username").value(charmroomUser.getUsername())
+					,jsonPath("$.data.email").value(charmroomUser.getEmail())
+					,jsonPath("$.data.nickname").value(charmroomUser.getNickname())
+					,jsonPath("$.data.withdraw").value(charmroomUser.isWithdraw())
+					,jsonPath("$.data.level").value(charmroomUser.getLevel().toString())
+					);
+		}
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
@@ -1,29 +1,42 @@
 package com.charmroom.charmroom.controller.integration;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-@Transactional
+import com.charmroom.charmroom.dto.presentation.UserDto.UserUpdateRequest;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.Comment;
+import com.charmroom.charmroom.entity.Point;
+import com.charmroom.charmroom.entity.enums.BoardType;
+import com.charmroom.charmroom.entity.enums.PointType;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.BoardRepository;
+import com.charmroom.charmroom.repository.CommentRepository;
+import com.charmroom.charmroom.repository.PointRepository;
+
 public class UserControllerIntegrationTestDy extends IntegrationTestBase {
-	
 	
 	@Nested
 	class GetMyInfo{
+		MockHttpServletRequestBuilder request = get("/api/user");
 		@Test
 		@WithCharmroomUserDetails
 		void success() throws Exception {
-			mockMvc.perform(get("/api/user"))
+			mockMvc.perform(request)
 			.andExpectAll(
 					status().isOk()
 					,jsonPath("$.data.username").value(charmroomUser.getUsername())
@@ -31,7 +44,164 @@ public class UserControllerIntegrationTestDy extends IntegrationTestBase {
 					,jsonPath("$.data.nickname").value(charmroomUser.getNickname())
 					,jsonPath("$.data.withdraw").value(charmroomUser.isWithdraw())
 					,jsonPath("$.data.level").value(charmroomUser.getLevel().toString())
+					,jsonPath("$.data.image.path").value(charmroomUser.getImage().getPath())
 					);
+		}
+	}
+	
+	@Nested
+	class UpdateMyInfo{
+		MockHttpServletRequestBuilder request = patch("/api/user");
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception {
+			// given
+			var dto = UserUpdateRequest.builder()
+					.nickname("test2")
+					.build();
+			
+			mockMvc.perform(request
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.nickname").value("test2")
+					)
+			;
+		}
+		
+		@Test
+		@WithCharmroomUserDetails
+		void failByDuplicatedNickname() throws Exception{
+			// given
+			var dto = UserUpdateRequest.builder()
+					.nickname(charmroomAdmin.getNickname())
+					.build();
+			mockMvc.perform(request
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.data.nickname").exists()
+					)
+			;
+		}
+	}
+	@Nested
+	class Withdraw{
+		MockHttpServletRequestBuilder request = patch("/api/user/withdraw");
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception{
+			// given
+			
+			// when
+			mockMvc.perform(request)
+			
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.withdraw").value(true)
+					)
+			;
+		}
+	}
+	@Nested
+	class GetMyPoints{
+		MockHttpServletRequestBuilder request = get("/api/user/point");
+		@Autowired
+		PointRepository pointRepository;
+		
+		private Point buildPoint() {
+			return Point.builder()
+					.user(charmroomUser)
+					.type(PointType.EARN)
+					.diff(300)
+					.build();
+		}
+	
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception{
+			// given			
+			List<Point> points = new ArrayList<>();
+			for(var i = 0; i < 10; i++) 
+				points.add(buildPoint());
+			for(var p : points) 
+				pointRepository.save(p);
+			
+			// when
+			mockMvc.perform(request)
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.totalElements").value(10)
+					,jsonPath("$.data.content").isArray()
+					,jsonPath("$.data.content.size()").value(10)
+					,jsonPath("$.data.content[0].username").value(charmroomUser.getUsername())
+					);
+		}
+	}
+	
+	@Nested
+	class GetMyComments{
+		MockHttpServletRequestBuilder request = get("/api/user/comment");
+		@Autowired
+		BoardRepository boardRepository;
+		@Autowired
+		ArticleRepository articleRepository;
+		@Autowired
+		CommentRepository commentRepository;
+		
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception {
+			// given
+			Board board = boardRepository.save(Board.builder()
+					.name("board")
+					.type(BoardType.LIST)
+					.build());
+			Article article = articleRepository.save(Article.builder()
+					.user(charmroomUser)
+					.board(board)
+					.title("title")
+					.body("body")
+					.build());
+			
+			List<Comment> parents = new ArrayList<>();
+			for(var i = 0; i < 3; i++) 
+				parents.add(
+						commentRepository.save(Comment.builder()
+								.user(charmroomUser)
+								.article(article)
+								.body(Integer.toString(i))
+								.build())
+						);
+			for(var p : parents) {
+				for (var j = 0; j < 2; j++) {
+					commentRepository.save(Comment.builder()
+							.user(charmroomUser)
+							.article(article)
+							.parent(p)
+							.body(Integer.toString(j))
+							.build());
+				}
+			}
+			
+			// when
+			mockMvc.perform(request)
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.totalElements").value(9)
+					,jsonPath("$.data.content").isArray()
+					,jsonPath("$.data.content.size()").value(9)
+					,jsonPath("$.data.content[*].parent").exists()
+					,jsonPath("$.data.content[*].childList[?(@.size() > 0)]").exists()
+					)
+			.andDo(print())
+			;
 		}
 	}
 }

--- a/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.charmroom.charmroom.dto.presentation.UserDto.UserUpdateRequest;
 import com.charmroom.charmroom.entity.Article;
@@ -155,6 +157,8 @@ public class UserControllerIntegrationTestDy extends IntegrationTestBase {
 		@Autowired
 		CommentRepository commentRepository;
 		
+		
+		
 		@Test
 		@WithCharmroomUserDetails
 		void success() throws Exception {
@@ -179,14 +183,15 @@ public class UserControllerIntegrationTestDy extends IntegrationTestBase {
 								.body(Integer.toString(i))
 								.build())
 						);
-			for(var p : parents) {
+			for(var parent : parents) {
 				for (var j = 0; j < 2; j++) {
-					commentRepository.save(Comment.builder()
+					var child = commentRepository.save(Comment.builder()
 							.user(charmroomUser)
 							.article(article)
-							.parent(p)
+							.parent(parent)
 							.body(Integer.toString(j))
 							.build());
+					parent.getChildList().add(child);
 				}
 			}
 			

--- a/src/test/java/com/charmroom/charmroom/controller/unit/CommentControllerUnitTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/unit/CommentControllerUnitTestDy.java
@@ -94,10 +94,14 @@ public class CommentControllerUnitTestDy {
 		@Test
 		void successWhenParentExists() throws Exception{
 			// given
-			mockedCommentDto.setParent(mockedCommentDto);
-			doReturn(mockedCommentDto).when(commentService).create(eq(1), any(), eq("test"), eq(1));
+			CommentDto mockedChildDto = CommentDto.builder()
+					.id(2)
+					.body("child")
+					.build();
+			mockedChildDto.setParent(mockedCommentDto);
+			doReturn(mockedChildDto).when(commentService).create(eq(1), any(), eq("child"), eq(1));
 			var request = CommentCreateRequestDto.builder()
-					.body("test")
+					.body("child")
 					.parentId(1)
 					.build();
 			// when
@@ -109,8 +113,8 @@ public class CommentControllerUnitTestDy {
 			// then
 			.andExpectAll(
 					status().isCreated(),
-					jsonPath("$.data.body").value("test"),
-					jsonPath("$.data.parentId").value(1)
+					jsonPath("$.data.body").value("child"),
+					jsonPath("$.data.parent.body").value("test")
 					)
 			;
 		}


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명

- User 컨트롤러 통합 테스트 코드 작성
- 통합 테스트에 사용할 베이스 클래스 작성 (하단 참고)
- DTO Mapper의 toDto 함수 일부 변경 (인자 추가, 하단 참고)

## 참고(선택)
> 리뷰어가 참고할만한 내용

## 통합 테스트 베이스 클래스
참고 https://github.com/CharmRoom/CharmRoom/commit/18d97c706b138d59c884a7f75f3ccae55947116b

통합테스트시 다음과 같이 상속하여 사용하면 됩니다.
```Java
public class UserControllerIntegrationTestDy extends IntegrationTestBase
```
### 개요
클래스 자체에 포함된 어노테이션
```Java
@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@AutoConfigureMockMvc
@Transactional
```

### Custom Annotation

#### 정의
클래스에는 다음과 같은 annotation을 정의하였습니다.
```Java 
@WithCharmroomUserDetails // 일반 사용자 Mock
@WithCharmroomAdminDetails // Admin Mock
```
각각의 어노테이션은 다음과 같은 의미를 가집니다.
```Java
// @WithCharmroomUserDetails
@WithUserDetails(
	value = "test", 
	setupBefore = TestExecutionEvent.TEST_EXECUTION,
	userDetailsServiceBeanName = "customUserDetailsService") 
// @WithCharmroomAdminDetails
@WithUserDetails(
	value = "admin", 
	setupBefore = TestExecutionEvent.TEST_EXECUTION,
	userDetailsServiceBeanName = "customUserDetailsService")
```

이 어노테이션에 해당하는 AuthenticationPrincipal은 멤버 변수로 포함되어있고
각각 다음과 같습니다.
```Java
// @WithCharmroomUserDetails
User charmroomUser;
// @WithCharmroomAdminDetails
User charmroomAdmin;
```

이를 위해서 매 테스트 메소드 실행전에 다음과 같은 코드가 실행되기 때문에
이 베이스 클래스 상속받아 사용시 중복된 데이터를 주의해주세요
```Java
@BeforeEach
void setup() throws Exception {
  charmroomUser = User.builder()
		  .username("test")
		  .password("")
		  .email("test@test.com")
		  .nickname("test")
		  .level(UserLevel.ROLE_BASIC)
		  .build();
  charmroomUser = userRepository.save(charmroomUser);
  charmroomAdmin = User.builder()
		  .username("admin")
		  .password("")
		  .email("admin@admin.com")
		  .nickname("admin")
		  .level(UserLevel.ROLE_ADMIN)
		  .build();
  charmroomAdmin = userRepository.save(charmroomAdmin);
}
```
#### 사용법

MockMvc에서 사용할 principal의 종류에 따라 어노테이션을 위에 붙여주면 됩니다.
데이터 검증은 위에 설명한 멤버 변수를 이용하여 가능합니다.
ex)
```Java
@Test
@WithCharmroomUserDetails
void success() throws Exception {
  mockMvc.perform(get("/api/user"))
  .andExpectAll(
	  status().isOk()
	  ,jsonPath("$.data.username").value(charmroomUser.getUsername())
	  ,jsonPath("$.data.email").value(charmroomUser.getEmail())
	  ,jsonPath("$.data.nickname").value(charmroomUser.getNickname())
	  ,jsonPath("$.data.withdraw").value(charmroomUser.isWithdraw())
	  ,jsonPath("$.data.level").value(charmroomUser.getLevel().toString())
	  );
}
```

#### 테스트 후 처리
테스트 후 발생한 리소스 삭제를 위한 코드가 추가되어있습니다.
```Java
@AfterAll
static void cleanUp(
	@Value("${charmroom.upload.image.path}") String imageUploadPath,
	@Value("${charmroom.upload.attachment.path}") String attachmentUploadPath) throws IOException {
  FileUtils.cleanDirectory(new File(imageUploadPath));
  FileUtils.cleanDirectory(new File(attachmentUploadPath));
}
```

### toDto 함수 변경 제안

참고 https://github.com/CharmRoom/CharmRoom/commit/15a373d5ffa0cb8722ec341a6406a70ee4ea2272

다음과 같이 비즈니스 dto의 toDto 함수에 ignore 변수를 추가하였습니다.

toDto 함수 내부에서 List로 변환해서 아래와 같이 사용합니다.
연관된 객체 중 dto로 돌려주기 싫은 내용을 문자열로 포함하여 인자로 주면 됩니다.

#### 바뀐 toDto 함수 예)
```Java
public static CommentDto toDto(Comment entity, String... ignore) {

...

      List<String> ignores = Arrays.asList(ignore);

...

      if (entity.getUser() != null && !ignores.contains("user")) {
            UserDto userDto = UserMapper.toDto(entity.getUser());
            dto.setUser(userDto);
      }
...
}
```
#### 사용법

아래와 같은 방식으로 사용할 수 있습니다.

```Java
CommentMapper.toDto(entity); // 모두 포함
CommentMapper.toDto(entity, "user", "parent"); // user, parent 제외
```

다른 Mapper에도 적용하는 것이 어떨까 하여 제안합니다.

### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)
Resolves #99 
참고 #96 

