### PR TITLE
Test/#96 integration test

### DIFF
--- a/src/main/java/com/charmroom/charmroom/config/WebConfig.java
+++ b/src/main/java/com/charmroom/charmroom/config/WebConfig.java
@@ -21,13 +21,13 @@ public class WebConfig implements WebMvcConfigurer{
 		if (!attachmentUploadPath.endsWith("/")) attachmentUploadPath += "/"; 
 		
 		registry
-			.addResourceHandler("/static/image/**")
+			.addResourceHandler("/resource/image/**")
 			.addResourceLocations("file:"+imageUploadPath)
 			// 개발중에는 캐시 사용하지 않음
 			//.setCacheControl(CacheControl.maxAge(Duration.ofHours(1L)).cachePublic())
 			.resourceChain(false);
 		registry
-			.addResourceHandler("/static/attachment/**")
+			.addResourceHandler("/resource/attachment/**")
 			.addResourceLocations("file:"+attachmentUploadPath)
 			//.setCacheControl(CacheControl.maxAge(Duration.ofHours(1L)).cachePublic())
 			.resourceChain(false);

--- a/src/main/java/com/charmroom/charmroom/controller/api/AdminController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/AdminController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/charmroom/charmroom/controller/api/AdminController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/AdminController.java
@@ -70,7 +70,7 @@ public class AdminController {
 			){
 		var dto = pointService.create(username, request.getType(), request.getDiff());
 		var response = PointMapper.toResponse(dto);
-		return CommonResponseDto.ok(response).toResponseEntity();
+		return CommonResponseDto.created(response).toResponseEntity();
 		
 	}
 	@PostMapping("/board")

--- a/src/main/java/com/charmroom/charmroom/controller/api/UserController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/UserController.java
@@ -21,6 +21,7 @@ import com.charmroom.charmroom.service.CommentService;
 import com.charmroom.charmroom.service.PointService;
 import com.charmroom.charmroom.service.UserService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -41,7 +42,7 @@ public class UserController {
 	@PatchMapping("")
 	public ResponseEntity<?> updateMyInfo(
 			@AuthenticationPrincipal User user,
-			@RequestBody UserUpdateRequest request){
+			@RequestBody @Valid UserUpdateRequest request){
 		var dto = userService.changeNickname(user.getUsername(), request.getNickname());
 		var response = UserMapper.toResponse(dto);
 		return CommonResponseDto.ok(response).toResponseEntity();

--- a/src/main/java/com/charmroom/charmroom/dto/business/ArticleMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/ArticleMapper.java
@@ -6,9 +6,10 @@ import java.util.List;
 import com.charmroom.charmroom.dto.presentation.ArticleDto.ArticleResponseDto;
 import com.charmroom.charmroom.entity.Article;
 
-public class ArticleMapper {
+import io.jsonwebtoken.lang.Arrays;
 
-	public static ArticleDto toDto(Article entity) {
+public class ArticleMapper {
+	public static ArticleDto toDto(Article entity, String... ignore) {
 		ArticleDto dto = ArticleDto.builder()
 				.id(entity.getId())
 				.title(entity.getTitle())
@@ -17,28 +18,27 @@ public class ArticleMapper {
 				.updatedAt(entity.getUpdatedAt())
 				.view(entity.getView())
 				.build();
-		if (entity.getUser() != null) {
+		List<String> ignores = Arrays.asList(ignore);
+		if (entity.getUser() != null && !ignores.contains("user")) {
 			dto.setUser(UserMapper.toDto(entity.getUser()));
 		}
-		if (entity.getBoard() != null) {
+		if (entity.getBoard() != null && !ignores.contains("board")) {
 			dto.setBoard(BoardMapper.toDto(entity.getBoard()));
 		}
-		if (entity.getCommentList().size() > 0) {
+		if (entity.getCommentList().size() > 0 && !ignores.contains("commentList")) {
 			var commentList = entity.getCommentList();
 			List<CommentDto> commentDtoList = new ArrayList<>();
 			for(var comment : commentList) {
-				CommentDto commentDto = CommentMapper.toDto(comment);
-				commentDto.setArticle(null);
+				CommentDto commentDto = CommentMapper.toDto(comment, "article");
 				commentDtoList.add(commentDto);
 			}
 			dto.setCommentList(commentDtoList);
 		}
-		if (entity.getAttachmentList().size() > 0) {
+		if (entity.getAttachmentList().size() > 0 && !ignores.contains("attachmentList")) {
 			var attachmentList = entity.getAttachmentList();
 			List<AttachmentDto> attachmentDtoList = new ArrayList<>();
 			for(var attachment : attachmentList) {
-				AttachmentDto attachmentDto = AttachmentMapper.toDto(attachment);
-				attachmentDto.setArticle(null);
+				AttachmentDto attachmentDto = AttachmentMapper.toDto(attachment, "article");
 				attachmentDtoList.add(attachmentDto);
 			}
 			dto.setAttachmentList(attachmentDtoList);
@@ -51,5 +51,4 @@ public class ArticleMapper {
 				.id(dto.getId())
 				.build();
 	}
-
 }

--- a/src/main/java/com/charmroom/charmroom/dto/business/AttachmentMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/AttachmentMapper.java
@@ -1,18 +1,22 @@
 package com.charmroom.charmroom.dto.business;
 
+import java.util.List;
+
 import com.charmroom.charmroom.entity.Attachment;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class AttachmentMapper {
-	public static AttachmentDto toDto(Attachment entity) {
+	public static AttachmentDto toDto(Attachment entity, String... ignore) {
 		AttachmentDto dto = AttachmentDto.builder()
 				.id(entity.getId())
 				.type(entity.getType())
 				.path(entity.getPath())
 				.originalName(entity.getOriginalName())
 				.build();
-		if (entity.getArticle() != null) {
-			ArticleDto articleDto = ArticleMapper.toDto(entity.getArticle());
-			articleDto.setAttachmentList(null);
+		List<String> ignores = Arrays.asList(ignore);
+		if (entity.getArticle() != null && !ignores.contains("article")) {
+			ArticleDto articleDto = ArticleMapper.toDto(entity.getArticle(), "attachmentList");
 			dto.setArticle(articleDto);
 		}
 		return dto;

--- a/src/main/java/com/charmroom/charmroom/dto/business/ClubMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/ClubMapper.java
@@ -6,10 +6,12 @@ import java.util.List;
 import com.charmroom.charmroom.entity.Club;
 import com.charmroom.charmroom.entity.User;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class ClubMapper {
-	public static ClubDto toDto(Club entity) {
+	public static ClubDto toDto(Club entity, String... ignore) {
 		if (entity == null) return null;
-		
+		var ignores = Arrays.asList(ignore);
 		ClubDto dto =  ClubDto.builder()
 				.id(entity.getId())
 				.name(entity.getName())
@@ -18,12 +20,11 @@ public class ClubMapper {
 				.image(ImageMapper.toDto(entity.getImage()))
 				.build();
 		
-		if (entity.getUserList().size() > 0) {
+		if (entity.getUserList().size() > 0 && !ignores.contains("userList")) {
 			List<User> userList = entity.getUserList();
 			List<UserDto> userDtoList = new ArrayList<>();
 			for (User user : userList) {
-				UserDto userDto = UserMapper.toDto(user);
-				userDto.setClub(null);
+				UserDto userDto = UserMapper.toDto(user, "club");
 				userDtoList.add(userDto);
 			}
 			dto.setUserList(userDtoList);

--- a/src/main/java/com/charmroom/charmroom/dto/business/CommentLikeMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/CommentLikeMapper.java
@@ -14,6 +14,8 @@ public class CommentLikeMapper {
 	}
 	
 	public static CommentLikeResponseDto toResponse(CommentLikeDto dto) {
+		if (dto == null)
+			return null;
 		return CommentLikeResponseDto.builder()
 				.type(dto.getType())
 				.build();

--- a/src/main/java/com/charmroom/charmroom/dto/business/CommentMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/CommentMapper.java
@@ -1,8 +1,5 @@
 package com.charmroom.charmroom.dto.business;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.charmroom.charmroom.dto.presentation.CommentDto.CommentResponseDto;
 import com.charmroom.charmroom.entity.Comment;
 

--- a/src/main/java/com/charmroom/charmroom/dto/business/CommentMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/CommentMapper.java
@@ -1,10 +1,15 @@
 package com.charmroom.charmroom.dto.business;
 
+import java.util.List;
+
 import com.charmroom.charmroom.dto.presentation.CommentDto.CommentResponseDto;
 import com.charmroom.charmroom.entity.Comment;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class CommentMapper {
-	public static CommentDto toDto(Comment entity) {
+	
+	public static CommentDto toDto(Comment entity, String... ignore) {
 		CommentDto dto = CommentDto.builder()
 				.id(entity.getId())
 				.body(entity.getBody())
@@ -12,27 +17,26 @@ public class CommentMapper {
 				.updatedAt(entity.getUpdatedAt())
 				.disabled(entity.isDisabled())
 				.build();
-		if (entity.getUser() != null) {
+		List<String> ignores = Arrays.asList(ignore);
+		if (entity.getUser() != null && !ignores.contains("user")) {
 			UserDto userDto = UserMapper.toDto(entity.getUser());
 			dto.setUser(userDto);
 		}
-		if (entity.getArticle() != null) {
-			ArticleDto articleDto = ArticleMapper.toDto(entity.getArticle());
-			articleDto.setCommentList(null);
+		if (entity.getArticle() != null && !ignores.contains("article")) {
+			ArticleDto articleDto = ArticleMapper.toDto(entity.getArticle(), "commentList");
 			dto.setArticle(articleDto);
 		}
-		if (entity.getParent() != null) {
-			CommentDto parent = CommentMapper.toDto(entity.getParent());
-			parent.setChildList(null);
+		if (entity.getParent() != null && !ignores.contains("parent")) {
+			CommentDto parent = CommentMapper.toDto(entity.getParent(), "childList");
 			dto.setParent(parent);
 		}
 		
-		for(var child : entity.getChildList()) {
-			CommentDto childDto = CommentMapper.toDto(child);
-			childDto.setParent(null);
-			dto.getChildList().add(childDto);
+		if (!ignores.contains("childList")) {
+			for(var child : entity.getChildList()) {
+				CommentDto childDto = CommentMapper.toDto(child, "parent");
+				dto.getChildList().add(childDto);
+			}
 		}
-		
 		
 		Integer like = 0, dislike = 0;
 		for(var cl : entity.getCommentLike()) {
@@ -47,6 +51,7 @@ public class CommentMapper {
 		return dto;
 	}
 
+	
 	public static CommentResponseDto toResponse(CommentDto dto) {
 		var response = CommentResponseDto.builder()
 				.id(dto.getId())
@@ -63,10 +68,17 @@ public class CommentMapper {
 			response.setUser(UserMapper.toResponse(dto.getUser()));
 		if (dto.getArticle() != null)
 			response.setArticleId(dto.getArticle().getId());
-		if (dto.getParent() != null)
-			response.setParentId(dto.getParent().getId());
+		if (dto.getParent() != null) {
+			var parent = toResponse(dto.getParent());
+			parent.getChildList().clear();
+			response.setParent(parent);
+		}
 		if (dto.getChildList().size() > 0) {
-			var childList = dto.getChildList().stream().map(child -> toResponse(child)).toList();
+			var childList = dto.getChildList().stream()
+					.map(child -> toResponse(child))
+					.toList()
+					;
+			childList.forEach(child -> child.setParent(null));
 			response.setChildList(childList);
 		}
 		

--- a/src/main/java/com/charmroom/charmroom/dto/business/ImageMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/ImageMapper.java
@@ -15,6 +15,8 @@ public class ImageMapper {
 	}
 	
 	public static ImageResponseDto toResponse(ImageDto dto) {
+		if (dto == null) return null;
+		
 		return ImageResponseDto.builder()
 				.id(dto.getId())
 				.originalName(dto.getOriginalName())

--- a/src/main/java/com/charmroom/charmroom/dto/business/PointMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/PointMapper.java
@@ -1,12 +1,16 @@
 package com.charmroom.charmroom.dto.business;
 
+import java.util.List;
+
 import com.charmroom.charmroom.dto.presentation.PointDto.PointResponseDto;
 import com.charmroom.charmroom.entity.Point;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class PointMapper {
-	public static PointDto toDto(Point entity) {
+	public static PointDto toDto(Point entity, String... ignore) {
 		if (entity == null) return null;
-		
+		List<String> ignores = Arrays.asList(ignore);
 		PointDto dto =  PointDto.builder()
 				.id(entity.getId())
 				.updatedAt(entity.getUpdatedAt())
@@ -14,9 +18,8 @@ public class PointMapper {
 				.diff(entity.getDiff())
 				.build();
 		
-		if (entity.getUser() != null) {
-			UserDto user = UserMapper.toDto(entity.getUser());
-			user.setPointList(null);
+		if (entity.getUser() != null && !ignores.contains("user")) {
+			UserDto user = UserMapper.toDto(entity.getUser(), "pointList");
 			dto.setUser(user);
 		}
 		return dto;

--- a/src/main/java/com/charmroom/charmroom/dto/business/UserMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/UserMapper.java
@@ -7,8 +7,10 @@ import com.charmroom.charmroom.dto.presentation.UserDto.UserResponseDto;
 import com.charmroom.charmroom.entity.Point;
 import com.charmroom.charmroom.entity.User;
 
+import io.jsonwebtoken.lang.Arrays;
+
 public class UserMapper {
-	public static UserDto toDto(User entity) {
+	public static UserDto toDto(User entity, String... ignore) {
 		if (entity == null) return null;
 		UserDto dto = UserDto.builder()
 				.id(entity.getId())
@@ -19,21 +21,20 @@ public class UserMapper {
 				.withdraw(entity.isWithdraw())
 				.level(entity.getLevel())
 				.build();
-		
-		if (entity.getImage() != null) {
+		List<String> ignores = Arrays.asList(ignore);
+		if (entity.getImage() != null && !ignores.contains("image")) {
 			dto.setImage(ImageMapper.toDto(entity.getImage()));
 		}
-		if (entity.getClub() != null) {
-			ClubDto club = ClubMapper.toDto(entity.getClub());
+		if (entity.getClub() != null && !ignores.contains("club")) {
+			ClubDto club = ClubMapper.toDto(entity.getClub(), "userList");
 			club.setUserList(null);
 			dto.setClub(club);
 		}
-		if (entity.getPointList().size() > 0) {
+		if (entity.getPointList().size() > 0 && !ignores.contains("pointList")) {
 			List<Point> pointList = entity.getPointList();
 			List<PointDto> pointDtoList = new ArrayList<>();
 			for(Point point : pointList) {
-				PointDto pointDto = PointMapper.toDto(point);
-				pointDto.setUser(null);
+				PointDto pointDto = PointMapper.toDto(point, "user");
 				pointDtoList.add(pointDto);
 			}
 			dto.setPointList(pointDtoList);
@@ -48,6 +49,7 @@ public class UserMapper {
 				.nickname(dto.getNickname())
 				.withdraw(dto.isWithdraw())
 				.level(dto.getLevel().getValue())
+				.image(ImageMapper.toResponse(dto.getImage()))
 				.build();
 	}
 }

--- a/src/main/java/com/charmroom/charmroom/dto/presentation/CommentDto.java
+++ b/src/main/java/com/charmroom/charmroom/dto/presentation/CommentDto.java
@@ -37,7 +37,7 @@ public class CommentDto {
 		private Integer id;
 		private UserResponseDto user;
 		private Integer articleId;
-		private Integer parentId;
+		private CommentResponseDto parent;
 		@Builder.Default
 		private List<CommentResponseDto> childList = new ArrayList<>();
 		private String body;

--- a/src/main/java/com/charmroom/charmroom/dto/presentation/UserDto.java
+++ b/src/main/java/com/charmroom/charmroom/dto/presentation/UserDto.java
@@ -52,6 +52,9 @@ public class UserDto {
 	@NoArgsConstructor
 	@Builder
 	public static class UserUpdateRequest{
+		@Size(min = 3, max = 30)
+		@NotEmpty
+		@ValidUser.Unique.Nickname
 		private String nickname;
 	}
 	

--- a/src/main/java/com/charmroom/charmroom/util/CharmroomUtil.java
+++ b/src/main/java/com/charmroom/charmroom/util/CharmroomUtil.java
@@ -41,8 +41,8 @@ public class CharmroomUtil {
 			this.attachmentUploadPath = attachmentUploadPath;
 			setPathReady(this.imageUploadPath);
 			setPathReady(this.attachmentUploadPath);
-			imageResourceUrl = "/image/";
-			attachmentResourceUrl = "/attachment/";
+			imageResourceUrl = "/resource/image/";
+			attachmentResourceUrl = "/resource/attachment/";
 		}
 		
 		public Image buildImage(MultipartFile image) {

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AdminControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AdminControllerIntegrationTestDy.java
@@ -1,0 +1,10 @@
+package com.charmroom.charmroom.controller.integration;
+
+import org.junit.jupiter.api.Nested;
+
+public class AdminControllerIntegrationTestDy extends IntegrationTestBase {
+	@Nested
+	class Users{
+		
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AdminControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AdminControllerIntegrationTestDy.java
@@ -1,10 +1,284 @@
 package com.charmroom.charmroom.controller.integration;
 
-import org.junit.jupiter.api.Nested;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import com.charmroom.charmroom.controller.integration.IntegrationTestBase.WithCharmroomAdminDetails;
+import com.charmroom.charmroom.dto.presentation.BoardDto.BoardCreateRequestDto;
+import com.charmroom.charmroom.dto.presentation.BoardDto.BoardUpdateRequestDto;
+import com.charmroom.charmroom.dto.presentation.PointDto.PointCreateRequestDto;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.Image;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.enums.BoardType;
+import com.charmroom.charmroom.entity.enums.PointType;
+import com.charmroom.charmroom.entity.enums.UserLevel;
+import com.charmroom.charmroom.repository.BoardRepository;
+import com.charmroom.charmroom.repository.ImageRepository;
+import com.charmroom.charmroom.repository.UserRepository;
+
+@WithCharmroomAdminDetails
 public class AdminControllerIntegrationTestDy extends IntegrationTestBase {
+	String urlPrefix = "/api/admin";
 	@Nested
 	class Users{
+		MockHttpServletRequestBuilder request = get(urlPrefix + "/user");
 		
+		@Autowired
+		UserRepository userRepository;
+		@Autowired
+		ImageRepository imageRepository;
+		
+		User buildUser(String prefix) {
+			Image image = Image.builder()
+					.originalName(prefix)
+					.path(prefix)
+					.build();
+			imageRepository.save(image);
+			return User.builder()
+					.username(prefix + "username")
+					.email(prefix + "email@email.com")
+					.password(prefix + "password")
+					.nickname(prefix + "nickname")
+					.image(image)
+					.level(UserLevel.ROLE_BASIC)
+					.build();
+		}
+		
+		@Test
+		void success() throws Exception {
+			// given
+			for (var i = 0; i < 10; i++) {
+				userRepository.save(buildUser(Integer.toString(i)));
+			}
+			// when
+			mockMvc.perform(request)
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.totalElements").value(12) // already 2 user created by superclass
+					,jsonPath("$.data.content").isArray()
+					,jsonPath("$.data.content.size()").value(10)
+					)
+			;
+		}
+		@Test
+		@WithCharmroomUserDetails
+		void failByPermission() throws Exception {
+			// given
+			// when
+			mockMvc.perform(request)
+			// then
+			.andExpect(status().isForbidden());
+		}
 	}
+	
+	@Nested
+	class ChangeUserGrade{
+		MockHttpServletRequestBuilder request = patch(urlPrefix + "/user/grade");
+		@Test
+		void success() throws Exception{
+			// given
+			// when
+			mockMvc.perform(request
+					.param("username", charmroomUser.getUsername())
+					.param("grade", UserLevel.ROLE_ADMIN.toString())
+					)
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.level").value(UserLevel.ROLE_ADMIN.toString())
+					)
+			;
+		}
+		
+		@Test
+		void failByNotfoundUser() throws Exception {
+			// given
+			// when
+			mockMvc.perform(request
+					.param("username", "SomeRandomName")
+					.param("grade", UserLevel.ROLE_ADMIN.toString())
+					)
+			// then
+			.andExpectAll(
+					status().isNotFound()
+					,jsonPath("$.code").value("12100")
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class ChangeUserWithdraw{
+		MockHttpServletRequestBuilder request = patch(urlPrefix + "/user/withdraw");
+		
+		@Test
+		void success() throws Exception {
+			// given
+			// when
+			mockMvc.perform(request
+					.param("username", charmroomUser.getUsername())
+					.param("withdraw", "true")
+					)
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.withdraw").value(true)
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class GivePoint {
+		
+		@Test
+		void success() throws Exception {
+			// given
+			PointCreateRequestDto dto = PointCreateRequestDto.builder()
+					.type(PointType.EARN.toString())
+					.diff(300)
+					.build(); 
+			// when
+			mockMvc.perform(post(urlPrefix + "/point/" + charmroomUser.getUsername())
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			// then
+			.andExpectAll(
+					status().isCreated()
+					,jsonPath("$.data.type").value(PointType.EARN.toString())
+					,jsonPath("$.data.diff").value(300)
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class CreateBoard {
+		MockHttpServletRequestBuilder request = post(urlPrefix + "/board");
+		@Test
+		void success() throws Exception {
+			// given
+			BoardCreateRequestDto dto = BoardCreateRequestDto.builder()
+					.name("board")
+					.type(BoardType.LIST.toString())
+					.build();
+			// when
+			mockMvc.perform(request
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			// then
+			.andExpectAll(
+					status().isCreated()
+					,jsonPath("$.data.name").value("board")
+					,jsonPath("$.data.type").value(BoardType.LIST.toString())
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class UpdateBoard {
+		@Autowired
+		BoardRepository boardRepository;
+		Board board = Board.builder()
+				.name("original")
+				.type(BoardType.LIST)
+				.build();
+		BoardUpdateRequestDto dto = BoardUpdateRequestDto.builder()
+				.name("changed")
+				.type(BoardType.GALLERY.toString())
+				.build();
+		@Test
+		void success() throws Exception {
+			// given
+			board = boardRepository.save(board);
+			// when
+			mockMvc.perform(post(urlPrefix + "/board/" + board.getId())
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.name").value("changed")
+					,jsonPath("$.data.type").value(BoardType.GALLERY.toString())
+					)
+			;
+		}
+		
+		@Test
+		void failByNotfoundBoardId() throws Exception {
+			// given
+			
+			// when
+			mockMvc.perform(post(urlPrefix + "/board/123456")
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			.andExpectAll(
+					status().isNotFound()
+					,jsonPath("$.code").value("04100")
+					)
+			;
+			
+		}
+	}
+	
+	@Nested
+	class ExposeBoard{
+		@Autowired
+		BoardRepository boardRepository;
+		Board board = Board.builder()
+				.name("original")
+				.type(BoardType.LIST)
+				.build();
+		@Test
+		void success() throws Exception {
+			// given
+			board = boardRepository.save(board);
+			// when
+			mockMvc.perform(patch(urlPrefix + "/board/" + board.getId())
+					.param("exposed", "true")
+					)
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.exposed").value(true)
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class DeleteBoard{
+		@Autowired
+		BoardRepository boardRepository;
+		Board board = Board.builder()
+				.name("original")
+				.type(BoardType.LIST)
+				.build();
+		@Test
+		void success() throws Exception {
+			// given
+			board = boardRepository.save(board);
+			// when
+			mockMvc.perform(delete(urlPrefix + "/board/" + board.getId()))
+			// then
+			.andExpect(status().isOk())
+			;
+		}
+	}
+	
 }

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
@@ -7,10 +7,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.tomcat.util.http.fileupload.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
@@ -20,6 +27,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.charmroom.charmroom.util.CharmroomUtil;
+
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
@@ -27,12 +36,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthControllerIntegrationTestDy {
 	@Autowired
 	MockMvc mockMvc;
+	@Autowired
+	CharmroomUtil.Upload upload;
 	
 	MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
 	String username = "test";
 	String password = "password";
 	String email = "test@test.com";
 	String nickname = "nickname";
+	
+	@AfterAll
+	static void cleanUp(
+			@Value("${charmroom.upload.image.path}") String imageUploadPath,
+			@Value("${charmroom.upload.attachment.path}") String attachmentUploadPath) throws IOException {
+		FileUtils.cleanDirectory(new File(imageUploadPath));
+		FileUtils.cleanDirectory(new File(attachmentUploadPath));
+	}
+	
 	
 	@Nested
 	class Signup {

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 
 import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,8 +26,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.charmroom.charmroom.util.CharmroomUtil;
-
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
@@ -36,8 +33,6 @@ import com.charmroom.charmroom.util.CharmroomUtil;
 public class AuthControllerIntegrationTestDy {
 	@Autowired
 	MockMvc mockMvc;
-	@Autowired
-	CharmroomUtil.Upload upload;
 	
 	MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
 	String username = "test";

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AuthControllerIntegrationTestDy.java
@@ -1,0 +1,269 @@
+package com.charmroom.charmroom.controller.integration;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+public class AuthControllerIntegrationTestDy {
+	@Autowired
+	MockMvc mockMvc;
+	
+	MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
+	String username = "test";
+	String password = "password";
+	String email = "test@test.com";
+	String nickname = "nickname";
+	
+	@Nested
+	class Signup {
+		String url = "/api/auth/signup";
+		@Test
+		void success() throws Exception {
+			// given
+			
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isCreated()
+					,jsonPath("$.code").value("CREATED")
+					,jsonPath("$.data.username").value(username)
+					,jsonPath("$.data.nickname").value(nickname)
+					,jsonPath("$.data.email").value(email)
+					)
+			;
+		}
+		@Test
+		void successWithoutImage() throws Exception {
+			// given
+			// when
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isCreated()
+					,jsonPath("$.code").value("CREATED")
+					,jsonPath("$.data.username").value(username)
+					,jsonPath("$.data.nickname").value(nickname)
+					,jsonPath("$.data.email").value(email)
+					)
+			;
+		}
+		@Test
+		void failPasswordValidation() throws Exception{
+			// given
+			// when
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", "1234")
+					.param("rePassword", "5678")
+					.param("email", email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.signupRequestDto", containsString("password"))
+					)
+			;
+		}
+		
+		@Test
+		void failDuplicatedUsername() throws Exception {
+			// given
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+			
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", "a" + email)
+					.param("nickname", "a" + nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.username", containsString("Duplicated"))
+					)
+			;
+		}
+		
+		@Test
+		void failDuplicatedEmail() throws Exception {
+			// given
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+			
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", "a" + username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", "a" + nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.email", containsString("Duplicated"))
+					)
+			;
+		}
+		
+		@Test
+		void failDuplicatedNickname() throws Exception{
+			// given
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", "a" + username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", "a" +  email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.nickname", containsString("Duplicated"))
+					)
+			;
+		}
+		
+		@Test
+		void failMultipleValidationError() throws Exception{
+			// given
+			mockMvc.perform(multipart(url)
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+			// when
+			mockMvc.perform(multipart(url)
+					.file(imageFile)
+					.param("username", username)
+					.param("password", "1234")
+					.param("rePassword", "5678")
+					.param("email", email)
+					.param("nickname", nickname)
+					)
+			// then
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.code").value("INVALID")
+					,jsonPath("$.data.signupRequestDto", containsString("password"))
+					,jsonPath("$.data.username", containsString("Duplicated"))
+					,jsonPath("$.data.email", containsString("Duplicated"))
+					,jsonPath("$.data.nickname", containsString("Duplicated"))
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class Login {
+		String url = "/api/auth/login";
+		
+		@BeforeEach
+		void setup() throws Exception {
+			// given
+			mockMvc.perform(multipart("/api/auth/signup")
+					.param("username", username)
+					.param("password", password)
+					.param("rePassword", password)
+					.param("email", email)
+					.param("nickname", nickname)
+					);
+		}
+		
+		@Test
+		void success() throws Exception {
+			// when
+			mockMvc.perform(post(url)
+					.param("username", username)
+					.param("password", password)
+					)
+			// then
+			.andExpectAll(
+					status().isOk()
+					,header().exists(HttpHeaders.AUTHORIZATION)
+					)
+			;
+		}
+		
+		@Test
+		void fail() throws Exception {
+			// when
+			mockMvc.perform(post(url)
+					.param("username", username)
+					.param("password", password + "1")
+					)
+			// then
+			.andExpect(
+					status().isUnauthorized()
+					)
+			;
+		}
+	}
+	
+	
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/BoardControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/BoardControllerIntegrationTestDy.java
@@ -1,0 +1,127 @@
+package com.charmroom.charmroom.controller.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.charmroom.charmroom.controller.integration.IntegrationTestBase.WithCharmroomUserDetails;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.enums.BoardType;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.BoardRepository;
+
+@WithCharmroomUserDetails
+public class BoardControllerIntegrationTestDy extends IntegrationTestBase {
+	@Autowired
+	BoardRepository boardRepository;
+	String urlPrefix = "/api/board";
+	
+	Board buildBoard(String name, BoardType type, Boolean exposed) {
+		return Board.builder()
+				.name(name)
+				.type(type)
+				.exposed(exposed)
+				.build();
+	}
+	
+	@Nested
+	class GetBoardsExposed{
+		
+		@Test
+		void success() throws Exception {
+			// given
+			var boardList = List.of(
+					buildBoard("1", BoardType.LIST, true)
+					,buildBoard("2", BoardType.GALLERY, false)
+					,buildBoard("3", BoardType.MARKET, true)
+					);
+					
+			for(var b : boardList) {
+				boardRepository.save(b);
+			}
+			mockMvc.perform(get(urlPrefix))
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data").isArray()
+					,jsonPath("$.data.size()").value(2)
+					)
+			.andDo(print())
+			;
+		}
+	}
+	
+	@Nested
+	class GetAllBoards{
+		String url = urlPrefix + "/all";
+		@Test
+		void success() throws Exception {
+			// given
+			for(var i = 0; i < 20; i++) {
+				Board b = buildBoard(Integer.toString(i), BoardType.values()[i % 3], i % 2 == 0);
+				boardRepository.save(b);
+			}
+			// when
+			mockMvc.perform(get(url))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.totalElements").value(20)
+					,jsonPath("$.data.content").isArray()
+					,jsonPath("$.data.content.size()").value(10)
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class GetArticles {
+		@Autowired
+		ArticleRepository articleRepository;
+		
+		String url = urlPrefix + "/";
+		
+		Article buildArticle(Board parent) {
+			return Article.builder()
+					.title("test")
+					.body("test")
+					.board(parent)
+					.build();
+		}
+		@Test
+		void success() throws Exception {
+			// given
+			Board b = buildBoard("name", BoardType.LIST, true);
+			boardRepository.save(b);
+			for(var i = 0; i < 15; i++) {
+				articleRepository.save(buildArticle(b));
+			}
+			
+			// when
+			mockMvc.perform(get(url + b.getId()))
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.totalElements").value(15)
+					,jsonPath("$.data.content").isArray()
+					,jsonPath("$.data.content.size()").value(10)
+					)
+			;	
+		}
+		@Test
+		void failByNotfoundBoard() throws Exception {
+			// when
+			mockMvc.perform(get(url + "12345"))
+			.andExpectAll(
+					status().isNotFound()
+					,jsonPath("$.code").value("04100")
+					);
+		}
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/CommentControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/CommentControllerIntegrationTestDy.java
@@ -1,0 +1,371 @@
+package com.charmroom.charmroom.controller.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import com.charmroom.charmroom.controller.integration.IntegrationTestBase.WithCharmroomUserDetails;
+import com.charmroom.charmroom.dto.presentation.CommentDto.CommentCreateRequestDto;
+import com.charmroom.charmroom.dto.presentation.CommentDto.CommentUpdateRequestDto;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.Comment;
+import com.charmroom.charmroom.entity.CommentLike;
+import com.charmroom.charmroom.entity.enums.BoardType;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.BoardRepository;
+import com.charmroom.charmroom.repository.CommentLikeRepository;
+import com.charmroom.charmroom.repository.CommentRepository;
+
+@WithCharmroomUserDetails
+public class CommentControllerIntegrationTestDy extends IntegrationTestBase {
+	@Autowired
+	BoardRepository boardRepository;
+	@Autowired
+	ArticleRepository articleRepository;
+	@Autowired
+	CommentRepository commentRepository;
+	
+	String urlPrefix = "/api/comment/";
+	
+	Board board = Board.builder()
+			.name("board")
+			.type(BoardType.LIST)
+			.build();
+	Article article = Article.builder()
+			.board(board)
+			.title("test")
+			.body("test")
+			.build();
+	
+	Comment buildComment(String body, Comment parent) {
+		return Comment.builder()
+				.article(article)
+				.user(charmroomUser)
+				.body(body)
+				.parent(parent)
+				.build();
+	}
+	Comment buildComment(String body) {
+		return Comment.builder()
+				.article(article)
+				.user(charmroomUser)
+				.body(body)
+				.build();
+	}
+	
+	@Nested
+	class Create{
+		String url = urlPrefix;
+		CommentCreateRequestDto dto = CommentCreateRequestDto.builder()
+				.body("123")
+				.build();
+		
+		@Test
+		void success() throws Exception {
+			// given
+			boardRepository.save(board);
+			Article savedArticle = articleRepository.save(article);
+			
+			// when
+			mockMvc.perform(post(url + savedArticle.getId())
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			// then
+			.andExpectAll(
+					status().isCreated()
+					,jsonPath("$.data.body").value(dto.getBody())
+					)
+			;
+		}
+		@Test
+		void successWithParentComment() throws Exception{
+			// given
+			boardRepository.save(board);
+			Article savedArticle = articleRepository.save(article);
+			Comment parent = commentRepository.save(Comment.builder()
+					.article(savedArticle)
+					.user(charmroomUser)
+					.body("parent")
+					.build());
+			
+			var childDto = CommentCreateRequestDto.builder()
+					.body("child")
+					.parentId(parent.getId())
+					.build();
+			// when
+			mockMvc.perform(post(url+savedArticle.getId())
+					.content(gson.toJson(childDto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			.andExpectAll(
+					status().isCreated()
+					,jsonPath("$.data.body").value(childDto.getBody())
+					,jsonPath("$.data.parent.body").value(parent.getBody())
+					)
+			;
+			
+		}
+		@Test
+		void failByNotFoundArticle() throws Exception {
+			// given
+			
+			// when
+			mockMvc.perform(post(url + "12345")
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			// then
+			.andExpectAll(
+					status().isNotFound()
+					,jsonPath("$.code").value("01100")
+					)
+			;
+			
+		}
+	}
+	
+	@Nested
+	class GetCommentList {
+		String url = urlPrefix;
+		@Test
+		void success() throws Exception {
+			// given
+			boardRepository.save(board);
+			Article savedArticle = articleRepository.save(article);
+			
+			for(var i = 0; i < 3; i++) {
+				Comment p = commentRepository.save(buildComment(Integer.toString(i)));
+				for(var j = 0; j < 3; j++) {
+					Comment c = commentRepository.save(
+							buildComment(Integer.toString(i) + "_" + Integer.toString(j), p));
+					p.getChildList().add(c);
+				}
+			}
+
+			// when
+			mockMvc.perform(get(url + savedArticle.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.totalElements").value(12)
+					,jsonPath("$.data.content").isArray()
+					,jsonPath("$.data.content.size()").value(10)
+					,jsonPath("$.data.content[0].body").value("2_2")
+					,jsonPath("$.data.content[0].parent.body").value("2")
+					,jsonPath("$.data.content[3].childList").isArray()
+					,jsonPath("$.data.content[3].childList.size()").value(3)
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class Update {
+		String url = urlPrefix;
+		CommentUpdateRequestDto dto = CommentUpdateRequestDto.builder()
+				.body("changed")
+				.build();
+		@Test
+		void success() throws Exception {
+			// given
+			boardRepository.save(board);
+			articleRepository.save(article);
+			Comment saved = commentRepository.save(buildComment("test"));
+			
+			// when
+			mockMvc.perform(patch(url + saved.getId())
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.body").value("changed")
+					)
+			;
+		}
+		
+		@Test
+		void failByNotFoundComment() throws Exception {
+			// given
+			
+			// when
+			mockMvc.perform(patch(url + "12345")
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			// then
+			.andExpectAll(
+					status().isNotFound()
+					,jsonPath("$.code").value("06100")
+					)
+			;
+		}
+	}
+	
+	@Nested
+	class Disable{
+		String url = urlPrefix;
+		@Test
+		void success() throws Exception {
+			// given 
+			boardRepository.save(board);
+			articleRepository.save(article);
+			Comment saved = commentRepository.save(buildComment("test"));
+			
+			// when
+			mockMvc.perform(delete(url + saved.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.disabled").value(true)
+					)
+			;
+			
+		}
+	}
+	
+	@Nested
+	class Like{
+		@Autowired
+		CommentLikeRepository commentLikeRepository;
+		
+		String url = urlPrefix + "like/";
+		@Test
+		void success() throws Exception {
+			// given
+			boardRepository.save(board);
+			articleRepository.save(article);
+			Comment saved = commentRepository.save(buildComment("test"));
+			
+			// when
+			mockMvc.perform(post(url + saved.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.type").value(true)
+					)
+			;
+		}
+		@Test
+		void successWhenAlreadyLike() throws Exception {
+			// given
+			boardRepository.save(board);
+			articleRepository.save(article);
+			Comment saved = commentRepository.save(buildComment("test"));
+			commentLikeRepository.save(CommentLike.builder()
+					.user(charmroomUser)
+					.comment(saved)
+					.type(true)
+					.build());
+			
+			// when
+			mockMvc.perform(post(url + saved.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data").doesNotExist()
+				)
+			;
+		}
+		
+		@Test
+		void successWhenAlreadyDislike() throws Exception {
+			// given
+			boardRepository.save(board);
+			articleRepository.save(article);
+			Comment saved = commentRepository.save(buildComment("test"));
+			commentLikeRepository.save(CommentLike.builder()
+					.user(charmroomUser)
+					.comment(saved)
+					.type(false)
+					.build());
+			
+			// when
+			mockMvc.perform(post(url + saved.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.type").value(true)
+				)
+			;
+		}
+	}
+	
+	@Nested
+	class Dislike{
+		@Autowired
+		CommentLikeRepository commentLikeRepository;
+		
+		String url = urlPrefix + "dislike/";
+		@Test
+		void success() throws Exception {
+			// given
+			boardRepository.save(board);
+			articleRepository.save(article);
+			Comment saved = commentRepository.save(buildComment("test"));
+			
+			// when
+			mockMvc.perform(post(url + saved.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.type").value(false)
+					)
+			;
+		}
+		@Test
+		void successWhenAlreadyLike() throws Exception {
+			// given
+			boardRepository.save(board);
+			articleRepository.save(article);
+			Comment saved = commentRepository.save(buildComment("test"));
+			commentLikeRepository.save(CommentLike.builder()
+					.user(charmroomUser)
+					.comment(saved)
+					.type(true)
+					.build());
+			
+			// when
+			mockMvc.perform(post(url + saved.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.type").value(false)
+				)
+			;
+		}
+		
+		@Test
+		void successWhenAlreadyDislike() throws Exception {
+			// given
+			boardRepository.save(board);
+			articleRepository.save(article);
+			Comment saved = commentRepository.save(buildComment("test"));
+			commentLikeRepository.save(CommentLike.builder()
+					.user(charmroomUser)
+					.comment(saved)
+					.type(false)
+					.build());
+			
+			// when
+			mockMvc.perform(post(url + saved.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data").doesNotExist()
+				)
+			;
+		}
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/DownloadControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/DownloadControllerIntegrationTestDy.java
@@ -1,0 +1,118 @@
+package com.charmroom.charmroom.controller.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+import com.charmroom.charmroom.controller.integration.IntegrationTestBase.WithCharmroomUserDetails;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Attachment;
+import com.charmroom.charmroom.entity.Image;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.AttachmentRepository;
+import com.charmroom.charmroom.repository.ImageRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+
+@WithCharmroomUserDetails
+public class DownloadControllerIntegrationTestDy extends IntegrationTestBase {
+	@Autowired
+	CharmroomUtil.Upload uploadUtil;
+	
+	String urlPrefix = "/download";
+	
+	@Nested
+	class DownloadImgae{
+		@Autowired
+		ImageRepository imageRepository;
+		String url = urlPrefix + "/image/";
+		MockMultipartFile mockedImage = new MockMultipartFile("image", "image.png", 
+				MediaType.IMAGE_PNG_VALUE, "test".getBytes());
+		Image image = uploadUtil.buildImage(mockedImage);
+		
+		@Test
+		void success() throws Exception {
+			// given
+			image = imageRepository.save(image);
+			
+			// when
+			mockMvc.perform(get(url + image.getId()))
+			
+			// then
+			.andExpectAll(
+					status().isOk()
+					,header().string(HttpHeaders.CONTENT_DISPOSITION
+							, "attachment; filename=\"" + image.getOriginalName() + "\";")
+					)
+			;
+		}
+		
+		@Test
+		void failByNotFoundImage() throws Exception {
+			// given
+			// when
+			mockMvc.perform(get(url + "12345"))
+			
+			// then
+			.andExpectAll(
+					status().isNotFound()
+					,jsonPath("$.code").value("08100")
+					);
+		}
+	}
+	
+	@Nested
+	class DownloadAttachment {
+		@Autowired
+		AttachmentRepository attachmentRepository;
+		@Autowired
+		ArticleRepository articleRepository;
+		
+		String url = urlPrefix + "/attachment/";
+		MockMultipartFile mockedAttach = new MockMultipartFile("attach", "attach.html", 
+				MediaType.TEXT_HTML_VALUE, "test".getBytes());
+		
+		@Test
+		void success() throws Exception {
+			// given
+			Article article = Article.builder()
+					.title("")
+					.body("")
+					.build();
+			article = articleRepository.save(article);
+			Attachment attachment = uploadUtil.buildAttachment(mockedAttach, article);
+			attachment = attachmentRepository.save(attachment);
+			article.getAttachmentList().add(attachment);
+			
+			// when
+			mockMvc.perform(get(url + attachment.getId()))
+			// then
+			.andExpectAll(
+					status().isOk()
+					,header().string(HttpHeaders.CONTENT_DISPOSITION
+							, "attachment; filename=\"" + attachment.getOriginalName() + "\";")
+					)
+			;
+		}
+		
+		@Test
+		void failByNotFoundAttachment() throws Exception {
+			// given
+			// when
+			mockMvc.perform(get(url + "12345"))
+			
+			// then
+			.andExpectAll(
+					status().isNotFound()
+					,jsonPath("$.code").value("03100")
+					);
+		}
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
@@ -21,7 +21,6 @@ import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
@@ -36,7 +36,7 @@ import com.google.gson.Gson;
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@Transactional(propagation = Propagation.SUPPORTS)
+@Transactional
 public class IntegrationTestBase {
 	@Autowired
 	MockMvc mockMvc;

--- a/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
@@ -1,0 +1,85 @@
+package com.charmroom.charmroom.controller.integration;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apache.tomcat.util.http.fileupload.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.enums.UserLevel;
+import com.charmroom.charmroom.repository.UserRepository;
+
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+public class IntegrationTestBase {
+	@Autowired
+	MockMvc mockMvc;
+	
+	@Autowired
+	UserRepository userRepository;
+	
+	User charmroomUser;
+	User charmroomAdmin;
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@Inherited
+	@WithUserDetails(
+			value = "test", 
+			setupBefore = TestExecutionEvent.TEST_EXECUTION,
+			userDetailsServiceBeanName = "customUserDetailsService") 
+	@interface WithCharmroomUserDetails {}
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@Inherited
+	@WithUserDetails(
+			value = "admin", 
+			setupBefore = TestExecutionEvent.TEST_EXECUTION,
+			userDetailsServiceBeanName = "customUserDetailsService")
+	@interface WithCharmroomAdminDetails{}
+	
+	@AfterAll
+	static void cleanUp(
+			@Value("${charmroom.upload.image.path}") String imageUploadPath,
+			@Value("${charmroom.upload.attachment.path}") String attachmentUploadPath) throws IOException {
+		FileUtils.cleanDirectory(new File(imageUploadPath));
+		FileUtils.cleanDirectory(new File(attachmentUploadPath));
+	}
+	
+	@BeforeEach
+	void setup() throws Exception {
+		charmroomUser = User.builder()
+				.username("test")
+				.password("")
+				.email("test@test.com")
+				.nickname("test")
+				.level(UserLevel.ROLE_BASIC)
+				.build();
+		charmroomUser = userRepository.save(charmroomUser);
+		charmroomAdmin = User.builder()
+				.username("admin")
+				.password("")
+				.email("admin@admin.com")
+				.nickname("admin")
+				.level(UserLevel.ROLE_ADMIN)
+				.build();
+		charmroomAdmin = userRepository.save(charmroomAdmin);
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
@@ -39,8 +39,8 @@ import com.google.gson.Gson;
 @Transactional
 public class IntegrationTestBase {
 	@Autowired
-	MockMvc mockMvc;
-	Gson gson;
+	public MockMvc mockMvc;
+	public Gson gson;
 	
 	@Autowired
 	private UserRepository userRepository;
@@ -50,8 +50,8 @@ public class IntegrationTestBase {
 	@Autowired
 	private CharmroomUtil.Upload uploadUtil;
 	
-	User charmroomUser;
-	User charmroomAdmin;
+	public User charmroomUser;
+	public User charmroomAdmin;
 	@Target({ ElementType.METHOD, ElementType.TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@Inherited
@@ -59,7 +59,7 @@ public class IntegrationTestBase {
 			value = "test", 
 			setupBefore = TestExecutionEvent.TEST_EXECUTION,
 			userDetailsServiceBeanName = "customUserDetailsService") 
-	@interface WithCharmroomUserDetails {}
+	public static @interface WithCharmroomUserDetails {}
 	@Target({ ElementType.METHOD, ElementType.TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@Inherited
@@ -67,7 +67,7 @@ public class IntegrationTestBase {
 			value = "admin", 
 			setupBefore = TestExecutionEvent.TEST_EXECUTION,
 			userDetailsServiceBeanName = "customUserDetailsService")
-	@interface WithCharmroomAdminDetails{}
+	public static @interface WithCharmroomAdminDetails{}
 	
 	@AfterAll
 	static void cleanUp(

--- a/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/IntegrationTestBase.java
@@ -15,26 +15,40 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.charmroom.charmroom.entity.Image;
 import com.charmroom.charmroom.entity.User;
 import com.charmroom.charmroom.entity.enums.UserLevel;
+import com.charmroom.charmroom.repository.ImageRepository;
 import com.charmroom.charmroom.repository.UserRepository;
+import com.charmroom.charmroom.util.CharmroomUtil;
+import com.google.gson.Gson;
 
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@Transactional
+@Transactional(propagation = Propagation.SUPPORTS)
 public class IntegrationTestBase {
 	@Autowired
 	MockMvc mockMvc;
+	Gson gson;
 	
 	@Autowired
-	UserRepository userRepository;
+	private UserRepository userRepository;
+	@Autowired
+	private ImageRepository imageRepository;
+	
+	@Autowired
+	private CharmroomUtil.Upload uploadUtil;
 	
 	User charmroomUser;
 	User charmroomAdmin;
@@ -65,12 +79,19 @@ public class IntegrationTestBase {
 	
 	@BeforeEach
 	void setup() throws Exception {
+		MultipartFile file = new MockMultipartFile("image", "profile.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
+		Image profile1 = uploadUtil.buildImage(file);
+		Image profile2 = uploadUtil.buildImage(file);
+		profile1 = imageRepository.save(profile1);
+		profile2 = imageRepository.save(profile2);
+		
 		charmroomUser = User.builder()
 				.username("test")
 				.password("")
 				.email("test@test.com")
 				.nickname("test")
 				.level(UserLevel.ROLE_BASIC)
+				.image(profile1)
 				.build();
 		charmroomUser = userRepository.save(charmroomUser);
 		charmroomAdmin = User.builder()
@@ -79,7 +100,9 @@ public class IntegrationTestBase {
 				.email("admin@admin.com")
 				.nickname("admin")
 				.level(UserLevel.ROLE_ADMIN)
+				.image(profile2)
 				.build();
 		charmroomAdmin = userRepository.save(charmroomAdmin);
+		gson = new Gson();
 	}
 }

--- a/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
@@ -1,0 +1,37 @@
+package com.charmroom.charmroom.controller.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+public class UserControllerIntegrationTestDy extends IntegrationTestBase {
+	
+	
+	@Nested
+	class GetMyInfo{
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception {
+			mockMvc.perform(get("/api/user"))
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.username").value(charmroomUser.getUsername())
+					,jsonPath("$.data.email").value(charmroomUser.getEmail())
+					,jsonPath("$.data.nickname").value(charmroomUser.getNickname())
+					,jsonPath("$.data.withdraw").value(charmroomUser.isWithdraw())
+					,jsonPath("$.data.level").value(charmroomUser.getLevel().toString())
+					);
+		}
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
@@ -1,29 +1,42 @@
 package com.charmroom.charmroom.controller.integration;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-@Transactional
+import com.charmroom.charmroom.dto.presentation.UserDto.UserUpdateRequest;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Board;
+import com.charmroom.charmroom.entity.Comment;
+import com.charmroom.charmroom.entity.Point;
+import com.charmroom.charmroom.entity.enums.BoardType;
+import com.charmroom.charmroom.entity.enums.PointType;
+import com.charmroom.charmroom.repository.ArticleRepository;
+import com.charmroom.charmroom.repository.BoardRepository;
+import com.charmroom.charmroom.repository.CommentRepository;
+import com.charmroom.charmroom.repository.PointRepository;
+
 public class UserControllerIntegrationTestDy extends IntegrationTestBase {
-	
 	
 	@Nested
 	class GetMyInfo{
+		MockHttpServletRequestBuilder request = get("/api/user");
 		@Test
 		@WithCharmroomUserDetails
 		void success() throws Exception {
-			mockMvc.perform(get("/api/user"))
+			mockMvc.perform(request)
 			.andExpectAll(
 					status().isOk()
 					,jsonPath("$.data.username").value(charmroomUser.getUsername())
@@ -31,7 +44,164 @@ public class UserControllerIntegrationTestDy extends IntegrationTestBase {
 					,jsonPath("$.data.nickname").value(charmroomUser.getNickname())
 					,jsonPath("$.data.withdraw").value(charmroomUser.isWithdraw())
 					,jsonPath("$.data.level").value(charmroomUser.getLevel().toString())
+					,jsonPath("$.data.image.path").value(charmroomUser.getImage().getPath())
 					);
+		}
+	}
+	
+	@Nested
+	class UpdateMyInfo{
+		MockHttpServletRequestBuilder request = patch("/api/user");
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception {
+			// given
+			var dto = UserUpdateRequest.builder()
+					.nickname("test2")
+					.build();
+			
+			mockMvc.perform(request
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.nickname").value("test2")
+					)
+			;
+		}
+		
+		@Test
+		@WithCharmroomUserDetails
+		void failByDuplicatedNickname() throws Exception{
+			// given
+			var dto = UserUpdateRequest.builder()
+					.nickname(charmroomAdmin.getNickname())
+					.build();
+			mockMvc.perform(request
+					.content(gson.toJson(dto))
+					.contentType(MediaType.APPLICATION_JSON)
+					)
+			.andExpectAll(
+					status().isNotAcceptable()
+					,jsonPath("$.data.nickname").exists()
+					)
+			;
+		}
+	}
+	@Nested
+	class Withdraw{
+		MockHttpServletRequestBuilder request = patch("/api/user/withdraw");
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception{
+			// given
+			
+			// when
+			mockMvc.perform(request)
+			
+			// then
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.withdraw").value(true)
+					)
+			;
+		}
+	}
+	@Nested
+	class GetMyPoints{
+		MockHttpServletRequestBuilder request = get("/api/user/point");
+		@Autowired
+		PointRepository pointRepository;
+		
+		private Point buildPoint() {
+			return Point.builder()
+					.user(charmroomUser)
+					.type(PointType.EARN)
+					.diff(300)
+					.build();
+		}
+	
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception{
+			// given			
+			List<Point> points = new ArrayList<>();
+			for(var i = 0; i < 10; i++) 
+				points.add(buildPoint());
+			for(var p : points) 
+				pointRepository.save(p);
+			
+			// when
+			mockMvc.perform(request)
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.totalElements").value(10)
+					,jsonPath("$.data.content").isArray()
+					,jsonPath("$.data.content.size()").value(10)
+					,jsonPath("$.data.content[0].username").value(charmroomUser.getUsername())
+					);
+		}
+	}
+	
+	@Nested
+	class GetMyComments{
+		MockHttpServletRequestBuilder request = get("/api/user/comment");
+		@Autowired
+		BoardRepository boardRepository;
+		@Autowired
+		ArticleRepository articleRepository;
+		@Autowired
+		CommentRepository commentRepository;
+		
+		@Test
+		@WithCharmroomUserDetails
+		void success() throws Exception {
+			// given
+			Board board = boardRepository.save(Board.builder()
+					.name("board")
+					.type(BoardType.LIST)
+					.build());
+			Article article = articleRepository.save(Article.builder()
+					.user(charmroomUser)
+					.board(board)
+					.title("title")
+					.body("body")
+					.build());
+			
+			List<Comment> parents = new ArrayList<>();
+			for(var i = 0; i < 3; i++) 
+				parents.add(
+						commentRepository.save(Comment.builder()
+								.user(charmroomUser)
+								.article(article)
+								.body(Integer.toString(i))
+								.build())
+						);
+			for(var p : parents) {
+				for (var j = 0; j < 2; j++) {
+					commentRepository.save(Comment.builder()
+							.user(charmroomUser)
+							.article(article)
+							.parent(p)
+							.body(Integer.toString(j))
+							.build());
+				}
+			}
+			
+			// when
+			mockMvc.perform(request)
+			.andExpectAll(
+					status().isOk()
+					,jsonPath("$.data.totalElements").value(9)
+					,jsonPath("$.data.content").isArray()
+					,jsonPath("$.data.content.size()").value(9)
+					,jsonPath("$.data.content[*].parent").exists()
+					,jsonPath("$.data.content[*].childList[?(@.size() > 0)]").exists()
+					)
+			.andDo(print())
+			;
 		}
 	}
 }

--- a/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.charmroom.charmroom.dto.presentation.UserDto.UserUpdateRequest;
 import com.charmroom.charmroom.entity.Article;
@@ -155,6 +157,8 @@ public class UserControllerIntegrationTestDy extends IntegrationTestBase {
 		@Autowired
 		CommentRepository commentRepository;
 		
+		
+		
 		@Test
 		@WithCharmroomUserDetails
 		void success() throws Exception {
@@ -179,14 +183,15 @@ public class UserControllerIntegrationTestDy extends IntegrationTestBase {
 								.body(Integer.toString(i))
 								.build())
 						);
-			for(var p : parents) {
+			for(var parent : parents) {
 				for (var j = 0; j < 2; j++) {
-					commentRepository.save(Comment.builder()
+					var child = commentRepository.save(Comment.builder()
 							.user(charmroomUser)
 							.article(article)
-							.parent(p)
+							.parent(parent)
 							.body(Integer.toString(j))
 							.build());
+					parent.getChildList().add(child);
 				}
 			}
 			

--- a/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestDy.java
@@ -2,21 +2,17 @@ package com.charmroom.charmroom.controller.integration;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.charmroom.charmroom.dto.presentation.UserDto.UserUpdateRequest;
 import com.charmroom.charmroom.entity.Article;
@@ -205,7 +201,6 @@ public class UserControllerIntegrationTestDy extends IntegrationTestBase {
 					,jsonPath("$.data.content[*].parent").exists()
 					,jsonPath("$.data.content[*].childList[?(@.size() > 0)]").exists()
 					)
-			.andDo(print())
 			;
 		}
 	}

--- a/src/test/java/com/charmroom/charmroom/controller/resource/ResourceHandlerTest.java
+++ b/src/test/java/com/charmroom/charmroom/controller/resource/ResourceHandlerTest.java
@@ -1,0 +1,60 @@
+package com.charmroom.charmroom.controller.resource;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+import com.charmroom.charmroom.controller.integration.IntegrationTestBase;
+import com.charmroom.charmroom.controller.integration.IntegrationTestBase.WithCharmroomUserDetails;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Attachment;
+import com.charmroom.charmroom.entity.Image;
+import com.charmroom.charmroom.util.CharmroomUtil;
+
+
+@WithCharmroomUserDetails
+public class ResourceHandlerTest extends IntegrationTestBase {
+	@Autowired
+	CharmroomUtil.Upload uploadUtil;
+	
+	@Nested
+	class ImageResourceHandler{
+		// given
+		MockMultipartFile mockedImage = new MockMultipartFile("image", "image.png", 
+				MediaType.IMAGE_PNG_VALUE, "test".getBytes());
+		Image image = uploadUtil.buildImage(mockedImage);
+		
+		@Test
+		void success() throws Exception {
+			// when
+			// then
+			mockMvc.perform(get(image.getPath()))
+			.andExpect(status().isOk())
+			;
+		}
+	}
+	@Nested
+	class AttachmentResourceHandler{
+		// given
+		MockMultipartFile mockedAttach = new MockMultipartFile("attach", "attach.html", 
+				MediaType.TEXT_HTML_VALUE, "test".getBytes());
+		Article article = Article.builder()
+				.title("")
+				.body("")
+				.build();
+		Attachment attachment = uploadUtil.buildAttachment(mockedAttach, article);
+		
+		@Test
+		void success() throws Exception {
+			// when
+			mockMvc.perform(get(attachment.getPath()))
+			// then
+			.andExpect(status().isOk());
+		}
+	}
+}

--- a/src/test/java/com/charmroom/charmroom/controller/unit/AdminControllerUnitTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/unit/AdminControllerUnitTestDy.java
@@ -190,7 +190,7 @@ public class AdminControllerUnitTestDy {
 					.contentType(MediaType.APPLICATION_JSON))
 			// then
 			.andExpectAll(
-					status().isOk()
+					status().isCreated()
 					,jsonPath("$.data.type").value("EARN")
 					,jsonPath("$.data.diff").value(400)
 					)

--- a/src/test/java/com/charmroom/charmroom/controller/unit/CommentControllerUnitTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/unit/CommentControllerUnitTestDy.java
@@ -94,10 +94,14 @@ public class CommentControllerUnitTestDy {
 		@Test
 		void successWhenParentExists() throws Exception{
 			// given
-			mockedCommentDto.setParent(mockedCommentDto);
-			doReturn(mockedCommentDto).when(commentService).create(eq(1), any(), eq("test"), eq(1));
+			CommentDto mockedChildDto = CommentDto.builder()
+					.id(2)
+					.body("child")
+					.build();
+			mockedChildDto.setParent(mockedCommentDto);
+			doReturn(mockedChildDto).when(commentService).create(eq(1), any(), eq("child"), eq(1));
 			var request = CommentCreateRequestDto.builder()
-					.body("test")
+					.body("child")
 					.parentId(1)
 					.build();
 			// when
@@ -109,8 +113,8 @@ public class CommentControllerUnitTestDy {
 			// then
 			.andExpectAll(
 					status().isCreated(),
-					jsonPath("$.data.body").value("test"),
-					jsonPath("$.data.parentId").value(1)
+					jsonPath("$.data.body").value("child"),
+					jsonPath("$.data.parent.body").value("test")
 					)
 			;
 		}

--- a/src/test/java/com/charmroom/charmroom/util/CharmroomUtilTest.java
+++ b/src/test/java/com/charmroom/charmroom/util/CharmroomUtilTest.java
@@ -46,8 +46,6 @@ public class CharmroomUtilTest {
 			File attachmentDir = new File(attachmentUploadPath);
 			FileUtils.cleanDirectory(imageDir);
 			FileUtils.cleanDirectory(attachmentDir);
-			FileUtils.deleteDirectory(imageDir);
-			FileUtils.deleteDirectory(attachmentDir);
 		}
 		@Nested
 		@Order(1)


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명


- [x] #97
- [x] #99
- [x] #101
- [x] #105
- [x] #107
- [x] #109

## 참고(선택)
> 리뷰어가 참고할만한 내용

참고 https://github.com/CharmRoom/CharmRoom/commit/18d97c706b138d59c884a7f75f3ccae55947116b

통합 테스트 베이스 클래스 만들었습니다.

통합테스트시 다음과 같이 상속하여 사용하면 됩니다.
```Java
public class UserControllerIntegrationTestDy extends IntegrationTestBase
```
## 개요
클래스 자체에 포함된 어노테이션
```Java
@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@AutoConfigureMockMvc
@Transactional
```

## Custom Annotation

### 정의
클래스에는 다음과 같은 annotation을 정의하였습니다.
```Java 
@WithCharmroomUserDetails // 일반 사용자 Mock
@WithCharmroomAdminDetails // Admin Mock
```
각각의 어노테이션은 다음과 같은 의미를 가집니다.
```Java
// @WithCharmroomUserDetails
@WithUserDetails(
	value = "test", 
	setupBefore = TestExecutionEvent.TEST_EXECUTION,
	userDetailsServiceBeanName = "customUserDetailsService") 
// @WithCharmroomAdminDetails
@WithUserDetails(
	value = "admin", 
	setupBefore = TestExecutionEvent.TEST_EXECUTION,
	userDetailsServiceBeanName = "customUserDetailsService")
```

이 어노테이션에 해당하는 AuthenticationPrincipal은 멤버 변수로 포함되어있고
각각 다음과 같습니다.
```Java
// @WithCharmroomUserDetails
User charmroomUser;
// @WithCharmroomAdminDetails
User charmroomAdmin;
```

이를 위해서 매 테스트 메소드 실행전에 다음과 같은 코드가 실행되기 때문에
이 베이스 클래스 상속받아 사용시 중복된 데이터를 주의해주세요
```Java
@BeforeEach
void setup() throws Exception {
  charmroomUser = User.builder()
		  .username("test")
		  .password("")
		  .email("test@test.com")
		  .nickname("test")
		  .level(UserLevel.ROLE_BASIC)
		  .build();
  charmroomUser = userRepository.save(charmroomUser);
  charmroomAdmin = User.builder()
		  .username("admin")
		  .password("")
		  .email("admin@admin.com")
		  .nickname("admin")
		  .level(UserLevel.ROLE_ADMIN)
		  .build();
  charmroomAdmin = userRepository.save(charmroomAdmin);
}
```
### 사용법

MockMvc에서 사용할 principal의 종류에 따라 어노테이션을 위에 붙여주면 됩니다.
데이터 검증은 위에 설명한 멤버 변수를 이용하여 가능합니다.
ex)
```Java
@Test
@WithCharmroomUserDetails
void success() throws Exception {
  mockMvc.perform(get("/api/user"))
  .andExpectAll(
	  status().isOk()
	  ,jsonPath("$.data.username").value(charmroomUser.getUsername())
	  ,jsonPath("$.data.email").value(charmroomUser.getEmail())
	  ,jsonPath("$.data.nickname").value(charmroomUser.getNickname())
	  ,jsonPath("$.data.withdraw").value(charmroomUser.isWithdraw())
	  ,jsonPath("$.data.level").value(charmroomUser.getLevel().toString())
	  );
}
```

## 테스트 후 처리
테스트 후 발생한 리소스 삭제를 위한 코드가 추가되어있습니다.
```Java
@AfterAll
static void cleanUp(
	@Value("${charmroom.upload.image.path}") String imageUploadPath,
	@Value("${charmroom.upload.attachment.path}") String attachmentUploadPath) throws IOException {
  FileUtils.cleanDirectory(new File(imageUploadPath));
  FileUtils.cleanDirectory(new File(attachmentUploadPath));
}
```

다음과 같이 비즈니스 dto의 toDto 함수에 ignore 변수를 추가하였습니다.

toDto 함수 내부에서 List로 변환해서 아래와 같이 사용합니다.
연관된 객체 중 dto로 돌려주기 싫은 내용을 문자열로 포함하여 인자로 주면 됩니다.

### 바뀐 toDto 함수 예)
```Java
public static CommentDto toDto(Comment entity, String... ignore) {

...

      List<String> ignores = Arrays.asList(ignore);

...

      if (entity.getUser() != null && !ignores.contains("user")) {
            UserDto userDto = UserMapper.toDto(entity.getUser());
            dto.setUser(userDto);
      }
...
}
```
### 사용법

아래와 같은 방식으로 사용할 수 있습니다.

```Java
CommentMapper.toDto(entity); // 모두 포함
CommentMapper.toDto(entity, "user", "parent"); // user, parent 제외
```

다른 Mapper에도 적용하는 것이 어떨까 하여 제안합니다.


### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)

Resolves #96 
