### PR TITLE
feat/#113 club controller

### DIFF
--- a/src/main/java/com/charmroom/charmroom/controller/api/ClubController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/ClubController.java
@@ -1,0 +1,119 @@
+package com.charmroom.charmroom.controller.api;
+
+import com.charmroom.charmroom.dto.business.ClubDto;
+import com.charmroom.charmroom.dto.business.ClubMapper;
+import com.charmroom.charmroom.dto.business.ImageDto;
+import com.charmroom.charmroom.dto.presentation.ClubDto.ClubCreateRequestDto;
+import com.charmroom.charmroom.dto.presentation.ClubDto.ClubResponseDto;
+import com.charmroom.charmroom.dto.presentation.CommonResponseDto;
+import com.charmroom.charmroom.dto.presentation.ClubDto.ClubUpdateRequestDto;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.service.ClubService;
+import lombok.RequiredArgsConstructor;
+import com.charmroom.charmroom.dto.presentation.ClubDto.ClubCreateRequestDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/club")
+@RequiredArgsConstructor
+public class ClubController {
+    private final ClubService clubService;
+
+    @PostMapping("/")
+    public ResponseEntity<?> createClub(
+            @ModelAttribute ClubCreateRequestDto requestDto
+    ) {
+        ClubDto club;
+
+        ClubDto clubDto = ClubDto.builder()
+                .name(requestDto.getName())
+                .description(requestDto.getDescription())
+                .contact(requestDto.getContact())
+                .build();
+
+        if (requestDto.getImage() != null && !requestDto.getImage().isEmpty()) {
+            club = clubService.createClub(clubDto, requestDto.getImage());
+        } else {
+            club = clubService.createClub(clubDto);
+        }
+
+        ClubResponseDto response = ClubMapper.toResponse(club);
+        return CommonResponseDto.created(response).toResponseEntity();
+    }
+
+    @GetMapping("/{clubId}")
+    public ResponseEntity<?> getClub(
+            @PathVariable("clubId") Integer clubId
+    ) {
+        ClubDto club = clubService.getClub(clubId);
+        ClubResponseDto response = ClubMapper.toResponse(club);
+
+        return CommonResponseDto.ok(response).toResponseEntity();
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<?> getClubList(
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<ClubDto> dtos = clubService.getAllClubsByPageable(pageable);
+        Page<ClubResponseDto> responseDtos = dtos.map(dto -> ClubMapper.toResponse(dto));
+
+        return CommonResponseDto.ok(responseDtos).toResponseEntity();
+    }
+
+    @PatchMapping("/{clubId}")
+    public ResponseEntity<?> updateClub(
+            @PathVariable("clubId") Integer clubId,
+            @AuthenticationPrincipal User user,
+            @RequestBody ClubUpdateRequestDto request
+    ) {
+        ClubDto clubDto = ClubDto.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .contact(request.getContact())
+                .build();
+
+        ClubDto dto = clubService.update(clubId, clubDto);
+
+        ClubResponseDto response = ClubMapper.toResponse(dto);
+        return CommonResponseDto.ok(response).toResponseEntity();
+    }
+
+    @PostMapping("/image/{clubId}")
+    public ResponseEntity<?> updateClubImage(
+            @PathVariable("clubId") Integer clubId,
+            @AuthenticationPrincipal User user,
+            @RequestPart("image") MultipartFile image
+    ) {
+        ClubDto dto = clubService.setImage(clubId, image);
+        ClubResponseDto response = ClubMapper.toResponse(dto);
+        return CommonResponseDto.ok(response).toResponseEntity();
+    }
+
+
+    @DeleteMapping("/{clubId}")
+    public ResponseEntity<?> deleteClub(
+            @PathVariable("clubId") Integer clubId,
+            @AuthenticationPrincipal User user
+    ) {
+        clubService.deleteClub(clubId);
+        return CommonResponseDto.ok().toResponseEntity();
+    }
+}

--- a/src/main/java/com/charmroom/charmroom/dto/business/ClubMapper.java
+++ b/src/main/java/com/charmroom/charmroom/dto/business/ClubMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.charmroom.charmroom.entity.Club;
 import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.dto.presentation.ClubDto.ClubResponseDto;
 
 import io.jsonwebtoken.lang.Arrays;
 
@@ -30,5 +31,15 @@ public class ClubMapper {
 			dto.setUserList(userDtoList);
 		}
 		return dto;
+	}
+
+	public static ClubResponseDto toResponse(ClubDto dto) {
+		return ClubResponseDto.builder()
+				.id(dto.getId())
+				.name(dto.getName())
+				.description(dto.getDescription())
+				.contact(dto.getContact())
+				.image(ImageMapper.toResponse(dto.getImage()))
+				.build();
 	}
 }

--- a/src/main/java/com/charmroom/charmroom/dto/presentation/ClubDto.java
+++ b/src/main/java/com/charmroom/charmroom/dto/presentation/ClubDto.java
@@ -1,0 +1,41 @@
+package com.charmroom.charmroom.dto.presentation;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ClubDto {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ClubCreateRequestDto {
+        private String name;
+        private String description;
+        private String contact;
+        private MultipartFile image;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ClubUpdateRequestDto {
+        private String name;
+        private String description;
+        private String contact;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class ClubResponseDto {
+        private Integer id;
+        private String name;
+        private String description;
+        private String contact;
+        private ImageDto.ImageResponseDto image;
+    }
+}

--- a/src/main/java/com/charmroom/charmroom/service/ClubService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ClubService.java
@@ -111,9 +111,9 @@ public class ClubService {
     }
 
     @Transactional
-    public ClubDto setImage(String clubName, MultipartFile imageFile) {
-        Club club = clubRepository.findByName(clubName).orElseThrow(() ->
-                new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubName: " + clubName));
+    public ClubDto setImage(Integer clubId, MultipartFile imageFile) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
 
         if (club.getImage() != null) {
             uploadUtil.deleteFile(club.getImage());

--- a/src/main/java/com/charmroom/charmroom/service/ClubService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ClubService.java
@@ -12,6 +12,7 @@ import com.charmroom.charmroom.util.CharmroomUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -51,8 +52,8 @@ public class ClubService {
         return clubRepository.existsByName(clubName);
     }
 
-    public Page<ClubDto> getAllClubsByPageable(PageRequest pageRequest) {
-        Page<Club> clubs = clubRepository.findAll(pageRequest);
+    public Page<ClubDto> getAllClubsByPageable(Pageable pageable) {
+        Page<Club> clubs = clubRepository.findAll(pageable);
         return clubs.map(club -> ClubMapper.toDto(club));
     }
 
@@ -88,6 +89,17 @@ public class ClubService {
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
 
         club.updateContact(newClubContact);
+        return ClubMapper.toDto(club);
+    }
+
+    public ClubDto update(Integer clubId, ClubDto clubDto) {
+        Club club = clubRepository.findById(clubId).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        club.updateName(clubDto.getName());
+        club.updateDescription(clubDto.getDescription());
+        club.updateContact(clubDto.getContact());
+
         return ClubMapper.toDto(club);
     }
 

--- a/src/test/java/com/charmroom/charmroom/controller/unit/ClubControllerUnitTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/unit/ClubControllerUnitTestCm.java
@@ -1,0 +1,292 @@
+package com.charmroom.charmroom.controller.unit;
+
+import com.charmroom.charmroom.controller.api.ClubController;
+import com.charmroom.charmroom.dto.business.ArticleDto;
+import com.charmroom.charmroom.dto.business.ClubDto;
+import com.charmroom.charmroom.dto.presentation.ClubDto.ClubUpdateRequestDto;
+import com.charmroom.charmroom.dto.business.ImageDto;
+import com.charmroom.charmroom.exception.BusinessLogicError;
+import com.charmroom.charmroom.exception.BusinessLogicException;
+import com.charmroom.charmroom.exception.ExceptionHandlerAdvice;
+import com.charmroom.charmroom.service.ClubService;
+import com.google.gson.Gson;
+import com.charmroom.charmroom.dto.presentation.ClubDto.ClubCreateRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.Validator;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class ClubControllerUnitTestCm {
+    @Mock
+    ClubService clubService;
+
+    @InjectMocks
+    ClubController clubController;
+
+    MockMvc mockMvc;
+    ClubDto mockedClubDto;
+    ImageDto mockedImageDto;
+    Gson gson;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(clubController)
+                .setControllerAdvice(new ExceptionHandlerAdvice())
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .setValidator(mock(Validator.class))
+                .build();
+
+        mockedImageDto = ImageDto.builder()
+                .id(1)
+                .path("")
+                .originalName("")
+                .build();
+
+        mockedClubDto = ClubDto.builder()
+                .id(1)
+                .name("")
+                .description("")
+                .contact("")
+                .image(mockedImageDto)
+                .build();
+
+        gson = new Gson();
+    }
+
+    @Nested
+    class Create {
+        @Test
+        void success_withoutImage() throws Exception {
+            // given
+            doReturn(mockedClubDto).when(clubService).createClub(any(ClubDto.class));
+
+            ClubCreateRequestDto request = ClubCreateRequestDto.builder()
+                    .name("")
+                    .description("")
+                    .contact("")
+                    .build();
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/club/")
+                    .content(gson.toJson(request))
+                    .contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpectAll(
+                    status().isCreated(),
+                    jsonPath("$.data.name").value(mockedClubDto.getName())
+            );
+        }
+
+        @Test
+        void success_withImage() throws Exception {
+            // given
+            MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
+
+            doReturn(mockedClubDto).when(clubService).createClub(any(ClubDto.class), eq(imageFile));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(multipart("/api/club/")
+                    .file(imageFile)
+                    .param("name", mockedClubDto.getName())
+                    .param("description", mockedClubDto.getDescription())
+                    .param("contact", mockedClubDto.getContact())
+            );
+
+            // then
+            resultActions.andExpectAll(
+                    status().isCreated(),
+                    jsonPath("$.code").value("CREATED"),
+                    jsonPath("$.data.name").value(mockedClubDto.getName())
+            );
+        }
+
+        @Test
+        void fail_duplicatedClubName() throws Exception {
+            // given
+            doThrow(new BusinessLogicException(BusinessLogicError.DUPLICATED_CLUBNAME))
+                    .when(clubService)
+                    .createClub(any(ClubDto.class));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(post("/api/club/")
+                    .param("name", mockedClubDto.getName())
+                    .param("description", mockedClubDto.getDescription())
+                    .param("contact", mockedClubDto.getContact())
+            );
+
+            // then
+            resultActions.andExpectAll(
+                    status().isBadRequest(),
+                    jsonPath("$.code").value("05000")
+            );
+        }
+    }
+
+    @Nested
+    class GetClub {
+        @Test
+        void success() throws Exception {
+            // given
+            doReturn(mockedClubDto).when(clubService).getClub(mockedClubDto.getId());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get("/api/club/1"));
+
+            // then
+            resultActions.andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.code").value("OK")
+            );
+        }
+
+        @Test
+        void fail() throws Exception {
+            // given
+            doThrow(new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB))
+                    .when(clubService)
+                    .getClub(mockedClubDto.getId());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get("/api/club/1"));
+
+            // then
+            resultActions.andExpectAll(
+                    status().isNotFound(),
+                    jsonPath("$.code").value("05100")
+            );
+        }
+    }
+
+    @Nested
+    class GetClubList {
+        @Test
+        void success() throws Exception {
+            // given
+            List<ClubDto> dtoList = List.of(mockedClubDto, mockedClubDto, mockedClubDto);
+
+            PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("id").descending());
+            PageImpl<ClubDto> dtoPage = new PageImpl<>(dtoList, pageRequest, 3);
+
+            doReturn(dtoPage).when(clubService).getAllClubsByPageable(pageRequest);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(get("/api/club/list"));
+
+            // then
+            resultActions.andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.data.totalElements").value(3),
+                    jsonPath("$.data.content").isArray(),
+                    jsonPath("$.data.content.size()").value(3),
+                    jsonPath("$.data.content[0].name").value(mockedClubDto.getName())
+            );
+        }
+    }
+
+    @Nested
+    class Update {
+        @Test
+        void success() throws Exception {
+            // given
+            doReturn(mockedClubDto).when(clubService).update(eq(1), any(ClubDto.class));
+
+            ClubUpdateRequestDto request = ClubUpdateRequestDto.builder()
+                    .name(mockedClubDto.getName())
+                    .description(mockedClubDto.getDescription())
+                    .contact(mockedClubDto.getContact())
+                    .build();
+
+            // when
+            ResultActions resultActions = mockMvc.perform(patch("/api/club/1")
+                    .content(gson.toJson(request))
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions.andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.data.name").value(mockedClubDto.getName())
+            );
+        }
+
+        @Test
+        void updateImage() throws Exception {
+            // given
+            MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
+
+            doReturn(mockedClubDto).when(clubService).setImage(eq(1), eq(imageFile));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(multipart("/api/club/image/1")
+                    .file(imageFile)
+            );
+
+            // then
+            resultActions.andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.code").value("OK")
+            );
+
+        }
+    }
+
+    @Nested
+    class Delete {
+        @Test
+        void success() throws Exception {
+            // given
+            doNothing().when(clubService).deleteClub(mockedClubDto.getId());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(delete("/api/club/1"));
+
+            // then
+            resultActions.andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.code").value("OK")
+            );
+        }
+    }
+
+    @Nested
+    class Register {
+        @Test
+        void success() throws Exception {
+            // given
+            // when
+            // then
+        }
+    }
+}

--- a/src/test/java/com/charmroom/charmroom/service/ClubServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ClubServiceUnitTest.java
@@ -312,12 +312,12 @@ public class ClubServiceUnitTest {
                     .originalName("")
                     .build();
 
-            doReturn(Optional.of(club)).when(clubRepository).findByName(club.getName());
+            doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
             doReturn(image).when(uploadUtil).buildImage(imageFile);
             doReturn(image).when(imageRepository).save(image);
 
             // when
-            ClubDto updated = clubService.setImage(club.getName(), imageFile);
+            ClubDto updated = clubService.setImage(club.getId(), imageFile);
 
             // then
             assertThat(updated).isNotNull();
@@ -328,11 +328,11 @@ public class ClubServiceUnitTest {
         void fail_ClubNotFound() {
             // given
             MockMultipartFile imageFile = new MockMultipartFile("file", "test.png", "image/png", "test".getBytes());
-            doReturn(Optional.empty()).when(clubRepository).findByName(club.getName());
+            doReturn(Optional.empty()).when(clubRepository).findById(club.getId());
 
             // when
             BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> {
-                clubService.setImage(club.getName(), imageFile);
+                clubService.setImage(club.getId(), imageFile);
             });
 
             // then
@@ -353,13 +353,13 @@ public class ClubServiceUnitTest {
                     .image(image)
                     .build();
 
-            doReturn(Optional.of(club)).when(clubRepository).findByName(club.getName());
+            doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
             doNothing().when(uploadUtil).deleteFile(club.getImage());
             doReturn(image).when(uploadUtil).buildImage(imageFile);
             doReturn(image).when(imageRepository).save(image);
 
             // when
-            ClubDto updated = clubService.setImage(club.getName(), imageFile);
+            ClubDto updated = clubService.setImage(club.getId(), imageFile);
 
             // then
             verify(uploadUtil).deleteFile(club.getImage());


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명



## 참고(선택)
> 리뷰어가 참고할만한 내용

@RequestParam으로 MultipartFile 타입의 이미지를 보낼 때 4xx 오류 발생
-> @RequestParam으론 단위테스트 불가
-> @RequestPart로 단위테스트 성공

(참고: https://velog.io/@zvyg1023/Spring-Boot-RequestPart%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-MultipartFile-DTO-%EC%B2%98%EB%A6%AC-%EB%B0%8F-%ED%85%8C%EC%8A%A4%ED%8A%B8)  
 



Multipart PATCH 테스트가 안되는 문제 발생
-> MockMVC에서 제공하는 MockMvcRequestBuilders에서 multipart 요청은 HTTP 메소드를 지정해주는 것이 불가능
-> Multipart 요청은 HTTP 메소드가 POST로 강제됨


(참고: https://mangkyu.tistory.com/218)

### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)
Resolves #113 
참고 #84

