### PR TITLE
Feat/#143 접근 권한 처리

### DIFF
--- a/src/main/java/com/charmroom/charmroom/config/SecurityConfig.java
+++ b/src/main/java/com/charmroom/charmroom/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -19,6 +21,7 @@ import com.charmroom.charmroom.service.CustomUserDetailsService;
 
 import lombok.RequiredArgsConstructor;
 
+@EnableMethodSecurity
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -41,13 +44,13 @@ public class SecurityConfig {
 		http.httpBasic((httpBasic) -> httpBasic.disable());
 		
 		// 경로 별 인가 작업
-		http.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
-				// API permit list
-				.requestMatchers("/api/auth/login", "/api/auth/signup", "/static/image/**").permitAll()
-				.requestMatchers("/", "/error/**" , "/login", "/auth/login", "/auth/signup").permitAll()
-				.requestMatchers("/api/admin/**").hasAnyAuthority("ROLE_ADMIN")
-				.anyRequest().authenticated()
-				);
+//		http.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+//				// API permit list
+//				.requestMatchers("/api/auth/login", "/api/auth/signup", "/static/image/**").permitAll()
+//				.requestMatchers("/", "/error/**" , "/login", "/auth/login", "/auth/signup").permitAll()
+//				.requestMatchers("/api/admin/**").hasAnyAuthority("ROLE_ADMIN")
+//				.anyRequest().authenticated()
+//				);
 		
 		// JWTFilter 등록
 		http.addFilterBefore(

--- a/src/main/java/com/charmroom/charmroom/controller/api/AdminController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/AdminController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -38,6 +39,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ROLE_ADMIN')")
 public class AdminController {
 	private final UserService userService;
 	private final BoardService boardService;

--- a/src/main/java/com/charmroom/charmroom/controller/api/ArticleController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/ArticleController.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,6 +38,7 @@ public class ArticleController {
     private final ArticleService articleService;
     private final ArticleLikeService articleLikeService;
 
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/{boardId}")
     public ResponseEntity<?> addArticle(
             @PathVariable(value = "boardId") Integer boardId,
@@ -56,6 +58,7 @@ public class ArticleController {
         return CommonResponseDto.created(responseDto).toResponseEntity();
     }
 
+    @PreAuthorize("permitAll()")
     @GetMapping("/{articleId}")
     public ResponseEntity<?> getArticle(
             @PathVariable("articleId") Integer articleId) {
@@ -64,6 +67,7 @@ public class ArticleController {
         return CommonResponseDto.ok(responseDto).toResponseEntity();
     }
 
+    @PreAuthorize("permitAll()")
     @GetMapping("/{boardId}/articles")
     public ResponseEntity<?> getArticleList(
             @PathVariable("boardId") Integer boardId,
@@ -75,6 +79,7 @@ public class ArticleController {
         return CommonResponseDto.ok(responseDtos).toResponseEntity();
     }
 
+    @PreAuthorize("hasRole('ROLE_BASIC')")
     @PatchMapping("/{articleId}")
     public ResponseEntity<?> updateArticle(
             @PathVariable("articleId") Integer articleId,
@@ -87,15 +92,17 @@ public class ArticleController {
         return CommonResponseDto.ok(responseDto).toResponseEntity();
     }
 
+    @PreAuthorize("hasRole('ROLE_BASIC')")
     @DeleteMapping("/{articleId}")
     public ResponseEntity<?> deleteArticle(
             @PathVariable("articleId") Integer articleId,
             @AuthenticationPrincipal User user
     ) {
-        articleService.deleteArticle(articleId);
+        articleService.deleteArticle(articleId, user.getUsername());
         return CommonResponseDto.ok().toResponseEntity();
     }
 
+    @PreAuthorize("hasRole('ROLE_BASIC')")
     @PostMapping("/like/{articleId}")
     public ResponseEntity<?> likeArticle(
             @AuthenticationPrincipal User user,
@@ -106,6 +113,7 @@ public class ArticleController {
         return CommonResponseDto.ok(response).toResponseEntity();
     }
 
+    @PreAuthorize("hasRole('ROLE_BASIC')")
     @PostMapping("/dislike/{articleId}")
     public ResponseEntity<?> dislikeArticle(
             @AuthenticationPrincipal User user,

--- a/src/main/java/com/charmroom/charmroom/controller/api/MarketController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/MarketController.java
@@ -20,6 +20,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,6 +41,7 @@ public class MarketController {
     private final ArticleService articleService;
     private final WishService wishService;
 
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/{boardId}")
     public ResponseEntity<?> addMarket(
             @PathVariable("boardId") Integer boardId,
@@ -69,6 +72,7 @@ public class MarketController {
         return CommonResponseDto.created(response).toResponseEntity();
     }
 
+    @PreAuthorize("permitAll()")
     @GetMapping("/{marketId}")
     public ResponseEntity<?> getMarket(
             @PathVariable("marketId") Integer marketId
@@ -79,6 +83,7 @@ public class MarketController {
         return CommonResponseDto.ok(response).toResponseEntity();
     }
 
+    @PreAuthorize("permitAll()")
     @GetMapping("/list/{boardId}")
     public ResponseEntity<?> getMarketList(
             @PathVariable("boardId") Integer boardId,
@@ -90,6 +95,7 @@ public class MarketController {
         return CommonResponseDto.ok(responseDtos).toResponseEntity();
     }
 
+    @PreAuthorize("hasRole('ROLE_BASIC')")
     @PatchMapping("/{marketId}")
     public ResponseEntity<?> updateMarket(
             @PathVariable("marketId") Integer marketId,
@@ -108,21 +114,23 @@ public class MarketController {
                 .state(request.getState())
                 .build();
 
-        MarketDto dto = marketService.update(marketId, marketDto);
+        MarketDto dto = marketService.update(marketId, marketDto, user.getUsername());
 
         MarketResponseDto response = MarketMapper.toResponse(dto);
         return CommonResponseDto.ok(response).toResponseEntity();
     }
 
+    @PreAuthorize("isAuthenticated()")
     @DeleteMapping("/{marketId}")
     public ResponseEntity<?> deleteMarket(
             @PathVariable("marketId") Integer marketId,
             @AuthenticationPrincipal User user
     ) {
-        marketService.delete(marketId);
+        marketService.delete(marketId, user.getUsername());
         return CommonResponseDto.ok().toResponseEntity();
     }
 
+    @PreAuthorize("hasRole('ROLE_BASIC')")
     @PostMapping("/{marketId}/wish")
     public ResponseEntity<?> wishMarket(
             @PathVariable("marketId") Integer marketId,

--- a/src/main/java/com/charmroom/charmroom/controller/api/UserController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/UserController.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -92,6 +93,7 @@ public class UserController {
 		return CommonResponseDto.ok(response).toResponseEntity();
 	}
 
+	@PreAuthorize("isAuthenticated()")
 	@GetMapping("/article")
 	public ResponseEntity<?> getMyArticles(
 			@AuthenticationPrincipal User user,
@@ -103,6 +105,7 @@ public class UserController {
 		return CommonResponseDto.ok(response).toResponseEntity();
 	}
 
+	@PreAuthorize("isAuthenticated()")
 	@GetMapping("/wish")
 	public ResponseEntity<?> getMyWishes(
 			@AuthenticationPrincipal User user,
@@ -114,6 +117,7 @@ public class UserController {
 		return CommonResponseDto.ok(response).toResponseEntity();
 	}
 
+	@PreAuthorize("isAuthenticated()")
 	@PostMapping("")
 	public ResponseEntity<?> subscribe(
 			@RequestBody SubscribeCreateRequestDto request
@@ -123,7 +127,7 @@ public class UserController {
 		return CommonResponseDto.ok(response).toResponseEntity();
 	}
 
-
+	@PreAuthorize("isAuthenticated()")
 	@GetMapping("/subscribe")
 	public ResponseEntity<?> getMySubscribes(
 			@AuthenticationPrincipal User user,

--- a/src/main/java/com/charmroom/charmroom/service/ArticleService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ArticleService.java
@@ -91,9 +91,14 @@ public class ArticleService {
         User user = userRepository.findByUsername(username).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_USER, "username: " + username));
 
+
         Article originalArticle = articleRepository.findById(articleId).orElseThrow(
                 () -> new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "articleId: " + articleId)
         );
+
+        if (!user.getUsername().equals(originalArticle.getUser().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_ARTICLE);
+        }
 
         if (!originalArticle.getUser().equals(user)) {
             throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_ARTICLE, "articleId: " + articleId);
@@ -104,11 +109,15 @@ public class ArticleService {
         return ArticleMapper.toDto(originalArticle);
     }
 
-    public void deleteArticle(Integer articleId) {
-        Article found = articleRepository.findById(articleId).orElseThrow(
+    public void deleteArticle(Integer articleId, String username) {
+        Article article = articleRepository.findById(articleId).orElseThrow(
                 () -> new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "articleId: " + articleId)
         );
 
-        articleRepository.delete(found);
+        if(!username.equals(article.getUser().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_ARTICLE, "articleId: " + articleId);
+        }
+
+        articleRepository.delete(article);
     }
 }

--- a/src/main/java/com/charmroom/charmroom/service/ClubRegisterService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ClubRegisterService.java
@@ -42,21 +42,29 @@ public class ClubRegisterService {
         return ClubRegisterMapper.toDto(saved);
     }
 
-    public Page<ClubRegisterDto> getClubRegistersByClub(Integer clubId, Pageable pageable) {
+    public Page<ClubRegisterDto> getClubRegistersByClub(Integer clubId, Pageable pageable, String username) {
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        if (!username.equals(club.getOwner().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_CLUB);
+        }
 
         Page<ClubRegister> clubRegisters = clubRegisterRepository.findAllByClub(club, pageable);
         return clubRegisters.map(ClubRegisterMapper::toDto);
     }
 
-    public void deleteClubRegister(String username, Integer clubId) {
+    public void deleteClubRegister(String username, Integer clubId, String ownerName) {
         User user = userRepository.findByUsername(username).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_USER, "username: " + username));
 
         Club club = clubRepository.findById(clubId).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        if (!ownerName.equals(club.getOwner().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_CLUB);
+        }
 
         Optional<ClubRegister> found = clubRegisterRepository.findByUserAndClub(user, club);
 

--- a/src/main/java/com/charmroom/charmroom/service/ClubService.java
+++ b/src/main/java/com/charmroom/charmroom/service/ClubService.java
@@ -102,9 +102,13 @@ public class ClubService {
     }
 
     @Transactional
-    public ClubDto update(Integer clubId, ClubDto clubDto) {
+    public ClubDto update(Integer clubId, ClubDto clubDto, String username) {
         Club club = clubRepository.findById(clubId).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        if (!username.equals(club.getOwner().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_CLUB);
+        }
 
         club.updateName(clubDto.getName());
         club.updateDescription(clubDto.getDescription());
@@ -114,28 +118,40 @@ public class ClubService {
     }
 
     @Transactional
-    public ClubDto changeOwner(Integer clubId, String username) {
+    public ClubDto changeOwner(Integer clubId, String updatedName, String username) {
         Club club = clubRepository.findById(clubId).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
 
-        User user = userRepository.findByUsername(username).orElseThrow(() ->
-                new BusinessLogicException(BusinessLogicError.NOTFOUND_USER, "username: " + username));
+        User user = userRepository.findByUsername(updatedName).orElseThrow(() ->
+                new BusinessLogicException(BusinessLogicError.NOTFOUND_USER, "username: " + updatedName));
+
+        if(!username.equals(club.getOwner().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_CLUB);
+        }
 
         club.updateOwner(user);
         return ClubMapper.toDto(club);
     }
 
-    public void deleteClub(Integer clubId) {
+    public void deleteClub(Integer clubId, String username) {
         Club club = clubRepository.findById(clubId).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        if (!username.equals(club.getOwner().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_CLUB);
+        }
 
         clubRepository.delete(club);
     }
 
     @Transactional
-    public ClubDto setImage(Integer clubId, MultipartFile imageFile) {
+    public ClubDto setImage(Integer clubId, MultipartFile imageFile, String username) {
         Club club = clubRepository.findById(clubId).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_CLUB, "clubId: " + clubId));
+
+        if (!username.equals(club.getOwner().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_CLUB);
+        }
 
         if (club.getImage() != null) {
             uploadUtil.deleteFile(club.getImage());

--- a/src/main/java/com/charmroom/charmroom/service/MarketService.java
+++ b/src/main/java/com/charmroom/charmroom/service/MarketService.java
@@ -126,9 +126,13 @@ public class MarketService {
         return MarketMapper.toDto(market);
     }
 
-    public MarketDto update(Integer marketId, MarketDto marketDto) {
+    public MarketDto update(Integer marketId, MarketDto marketDto, String username) {
         Market market = marketRepository.findById(marketId).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "marketId: " + marketId));
+
+        if(!username.equals(market.getArticle().getUser().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_ARTICLE, "marketId: " + marketId);
+        }
 
         market.getArticle().updateTitle(marketDto.getArticle().getTitle());
         market.getArticle().updatedBody(marketDto.getArticle().getBody());
@@ -139,9 +143,13 @@ public class MarketService {
         return MarketMapper.toDto(market);
     }
 
-    public void delete(Integer marketId) {
+    public void delete(Integer marketId, String username) {
         Market market = marketRepository.findById(marketId).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_ARTICLE, "marketId: " + marketId));
+
+        if(!username.equals(market.getArticle().getUser().getUsername())) {
+            throw new BusinessLogicException(BusinessLogicError.UNAUTHORIZED_ARTICLE, "marketId: " + marketId);
+        }
 
         marketRepository.delete(market);
         articleRepository.delete(market.getArticle());

--- a/src/test/java/com/charmroom/charmroom/controller/integration/ClubControllerIntegrationTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/ClubControllerIntegrationTestCm.java
@@ -54,7 +54,7 @@ public class ClubControllerIntegrationTestCm extends IntegrationTestBase {
                 .name(prefix)
                 .description(prefix + "description")
                 .contact(prefix + "contact")
-                .owner(charmroomAdmin)
+                .owner(charmroomUser)
                 .image(image)
                 .build();
     }

--- a/src/test/java/com/charmroom/charmroom/controller/integration/MarketControllerIntegrationTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/MarketControllerIntegrationTestCm.java
@@ -197,7 +197,24 @@ public class MarketControllerIntegrationTestCm extends IntegrationTestBase {
         @Test
         void success() throws Exception {
             // given
-            Market market = marketRepository.save(buildMarket("test"));
+            Board board = boardRepository.save(Board.builder()
+                    .name("board")
+                    .type(BoardType.LIST)
+                    .build());
+
+            Article article = articleRepository.save(Article.builder()
+                    .user(charmroomUser)
+                    .board(board)
+                    .title("test")
+                    .body("test")
+                    .build());
+
+            Market market = marketRepository.save(Market.builder()
+                    .article(article)
+                    .tag("test")
+                    .state(MarketArticleState.SALE)
+                    .price(1000)
+                    .build());
 
             ArticleUpdateRequestDto articleDto = ArticleUpdateRequestDto.builder()
                     .title("updated")
@@ -230,7 +247,24 @@ public class MarketControllerIntegrationTestCm extends IntegrationTestBase {
         @Test
         void success() throws Exception {
             // given
-            Market market = marketRepository.save(buildMarket("test"));
+            Board board = boardRepository.save(Board.builder()
+                    .name("board")
+                    .type(BoardType.LIST)
+                    .build());
+
+            Article article = articleRepository.save(Article.builder()
+                    .user(charmroomUser)
+                    .board(board)
+                    .title("test")
+                    .body("test")
+                    .build());
+
+            Market market = marketRepository.save(Market.builder()
+                    .article(article)
+                    .tag("test")
+                    .state(MarketArticleState.SALE)
+                    .price(1000)
+                    .build());
 
             // when
             ResultActions resultActions = mockMvc.perform(delete(urlPrefix + market.getId()));

--- a/src/test/java/com/charmroom/charmroom/controller/integration/MarketControllerIntegrationTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/MarketControllerIntegrationTestCm.java
@@ -10,12 +10,15 @@ import com.charmroom.charmroom.dto.presentation.ArticleDto.ArticleUpdateRequestD
 import com.charmroom.charmroom.entity.Article;
 import com.charmroom.charmroom.entity.Board;
 import com.charmroom.charmroom.entity.Market;
+import com.charmroom.charmroom.entity.User;
 import com.charmroom.charmroom.entity.Wish;
 import com.charmroom.charmroom.entity.enums.BoardType;
 import com.charmroom.charmroom.entity.enums.MarketArticleState;
+import com.charmroom.charmroom.entity.enums.UserLevel;
 import com.charmroom.charmroom.repository.ArticleRepository;
 import com.charmroom.charmroom.repository.BoardRepository;
 import com.charmroom.charmroom.repository.MarketRepository;
+import com.charmroom.charmroom.repository.UserRepository;
 import com.charmroom.charmroom.repository.WishRepository;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -51,6 +54,7 @@ public class MarketControllerIntegrationTestCm extends IntegrationTestBase {
             .build();
 
     Article article = Article.builder()
+            .user(charmroomUser)
             .board(board)
             .title("test")
             .body("test")

--- a/src/test/java/com/charmroom/charmroom/controller/unit/ArticleControllerUnitTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/unit/ArticleControllerUnitTestCm.java
@@ -3,7 +3,9 @@ package com.charmroom.charmroom.controller.unit;
 import com.charmroom.charmroom.controller.api.ArticleController;
 import com.charmroom.charmroom.dto.business.ArticleDto;
 import com.charmroom.charmroom.dto.business.ArticleLikeDto;
+import com.charmroom.charmroom.dto.business.UserDto;
 import com.charmroom.charmroom.dto.presentation.ArticleDto.ArticleUpdateRequestDto;
+import com.charmroom.charmroom.entity.enums.UserLevel;
 import com.charmroom.charmroom.exception.ExceptionHandlerAdvice;
 import com.charmroom.charmroom.service.ArticleLikeService;
 import com.charmroom.charmroom.service.ArticleService;
@@ -54,6 +56,7 @@ public class ArticleControllerUnitTestCm {
 
     MockMvc mockMvc;
     ArticleDto mockedArticleDto;
+    UserDto mockedUserDto;
     Gson gson;
 
     @BeforeEach
@@ -65,8 +68,17 @@ public class ArticleControllerUnitTestCm {
                 .setValidator(mock(Validator.class))
                 .build();
 
+        mockedUserDto = UserDto.builder()
+                .level(UserLevel.ROLE_BASIC)
+                .username("username")
+                .password("password")
+                .email("test@test.com")
+                .nickname("nickname")
+                .build();
+
         mockedArticleDto = ArticleDto.builder()
                 .id(1)
+                .user(mockedUserDto)
                 .title("test")
                 .body("test")
                 .build();
@@ -189,7 +201,7 @@ public class ArticleControllerUnitTestCm {
         @Test
         void success() throws Exception {
             // given
-            doNothing().when(articleService).deleteArticle(1);
+            doNothing().when(articleService).deleteArticle(eq(1), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(delete("/api/article/1"));

--- a/src/test/java/com/charmroom/charmroom/controller/unit/ClubControllerUnitTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/unit/ClubControllerUnitTestCm.java
@@ -36,6 +36,7 @@ import org.springframework.validation.Validator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -251,7 +252,7 @@ public class ClubControllerUnitTestCm {
         @Test
         void success() throws Exception {
             // given
-            doReturn(mockedClubDto).when(clubService).update(eq(1), any(ClubDto.class));
+            doReturn(mockedClubDto).when(clubService).update(eq(1), any(ClubDto.class), any());
 
             ClubUpdateRequestDto request = ClubUpdateRequestDto.builder()
                     .name(mockedClubDto.getName())
@@ -271,13 +272,16 @@ public class ClubControllerUnitTestCm {
                     jsonPath("$.data.name").value(mockedClubDto.getName())
             );
         }
+    }
 
+    @Nested
+    class SetImage {
         @Test
-        void updateImage() throws Exception {
+        void setImage() throws Exception {
             // given
             MockMultipartFile imageFile = new MockMultipartFile("image", "test.png", MediaType.IMAGE_PNG_VALUE, "test".getBytes());
 
-            doReturn(mockedClubDto).when(clubService).setImage(eq(1), eq(imageFile));
+            doReturn(mockedClubDto).when(clubService).setImage(eq(1), eq(imageFile), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(multipart("/api/club/image/1")
@@ -289,16 +293,16 @@ public class ClubControllerUnitTestCm {
                     status().isOk(),
                     jsonPath("$.code").value("OK")
             );
-
         }
     }
+
 
     @Nested
     class ChangeOwner {
         @Test
         void success() throws Exception {
             // given
-            doReturn(mockedClubDto).when(clubService).changeOwner(eq(1), any());
+            doReturn(mockedClubDto).when(clubService).changeOwner(eq(1), any(), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(patch("/api/club/owner/1")
@@ -319,7 +323,7 @@ public class ClubControllerUnitTestCm {
         @Test
         void success() throws Exception {
             // given
-            doNothing().when(clubService).deleteClub(mockedClubDto.getId());
+            doNothing().when(clubService).deleteClub(eq(mockedClubDto.getId()), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(delete("/api/club/1"));
@@ -392,7 +396,8 @@ public class ClubControllerUnitTestCm {
 
             PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("userId").descending());
             PageImpl<ClubRegisterDto> dtoPage = new PageImpl<>(dtoList, pageRequest, 3);
-            doReturn(dtoPage).when(clubRegisterService).getClubRegistersByClub(1, pageRequest);
+
+            doReturn(dtoPage).when(clubRegisterService).getClubRegistersByClub(eq(1), eq(pageRequest), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(get("/api/club/register/1"));
@@ -430,16 +435,18 @@ public class ClubControllerUnitTestCm {
         @Test
         void success() throws Exception {
             // given
-            doNothing().when(clubRegisterService).deleteClubRegister(any(), eq(1));
+            doNothing().when(clubRegisterService).deleteClubRegister(any(), eq(1), any());
 
             // when
-            ResultActions resultActions = mockMvc.perform(delete("/api/club/register/1"));
+            ResultActions resultActions = mockMvc.perform(delete("/api/club/register/1")
+                    .param("username", mockedUserDto.getUsername()));
+
             // then
             resultActions.andExpectAll(
                     status().isOk(),
                     jsonPath("$.code").value("OK")
             );
-            verify(clubRegisterService).deleteClubRegister(any(), eq(1));
+            verify(clubRegisterService).deleteClubRegister(any(), eq(1), any());
         }
 
         @Test
@@ -447,10 +454,11 @@ public class ClubControllerUnitTestCm {
             // given
             doThrow(new BusinessLogicException(BusinessLogicError.NOTFOUND_USER))
                     .when(clubRegisterService)
-                    .deleteClubRegister(any(), eq(1));
+                    .deleteClubRegister(any(), eq(1), any());
 
             // when
-            ResultActions resultActions = mockMvc.perform(delete("/api/club/register/1"));
+            ResultActions resultActions = mockMvc.perform(delete("/api/club/register/1")
+                    .param("username", mockedUserDto.getUsername()));
 
             // then
             resultActions.andExpectAll(

--- a/src/test/java/com/charmroom/charmroom/controller/unit/MarketControllerUnitTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/unit/MarketControllerUnitTestCm.java
@@ -195,7 +195,7 @@ public class MarketControllerUnitTestCm {
         @Test
         void success() throws Exception {
             // given
-            doReturn(mockedMarketDto).when(marketService).update(eq(1), any(MarketDto.class));
+            doReturn(mockedMarketDto).when(marketService).update(eq(1), any(MarketDto.class), any());
 
             ArticleUpdateRequestDto article = ArticleUpdateRequestDto.builder()
                     .title(mockedMarketDto.getArticle().getTitle())
@@ -229,7 +229,7 @@ public class MarketControllerUnitTestCm {
         @Test
         void success() throws Exception{
             // given
-            doNothing().when(marketService).delete(eq(1));
+            doNothing().when(marketService).delete(eq(1), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(delete("/api/market/1"));

--- a/src/test/java/com/charmroom/charmroom/service/ArticleServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ArticleServiceUnitTest.java
@@ -303,7 +303,7 @@ public class ArticleServiceUnitTest {
             doReturn(Optional.of(article)).when(articleRepository).findById(article.getId());
 
             // when
-            articleService.deleteArticle(article.getId());
+            articleService.deleteArticle(article.getId(), user.getUsername());
 
             // then
             verify(articleRepository).findById(article.getId());
@@ -317,7 +317,7 @@ public class ArticleServiceUnitTest {
 
             // when
             BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () ->
-                    articleService.deleteArticle(article.getId()));
+                    articleService.deleteArticle(article.getId(), user.getUsername()));
 
             // then
             verify(articleRepository).findById(article.getId());

--- a/src/test/java/com/charmroom/charmroom/service/ClubRegisterServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ClubRegisterServiceUnitTest.java
@@ -125,7 +125,7 @@ public class ClubRegisterServiceUnitTest {
             doReturn(registerPage).when(clubRegisterRepository).findAllByClub(club, pageRequest);
 
             // when
-            Page<ClubRegisterDto> clubRegisters = clubRegisterService.getClubRegistersByClub(club.getId(), pageRequest);
+            Page<ClubRegisterDto> clubRegisters = clubRegisterService.getClubRegistersByClub(club.getId(), pageRequest, owner.getUsername());
 
             // then
             assertThat(clubRegisters).hasSize(3);
@@ -141,7 +141,7 @@ public class ClubRegisterServiceUnitTest {
             doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
             doReturn(Optional.of(clubRegister)).when(clubRegisterRepository).findByUserAndClub(user, club);
             // when
-            clubRegisterService.deleteClubRegister(user.getUsername(), club.getId());
+            clubRegisterService.deleteClubRegister(user.getUsername(), club.getId(), owner.getUsername());
             // then
             verify(clubRegisterRepository).findByUserAndClub(user, club);
             verify(clubRegisterRepository).delete(clubRegister);

--- a/src/test/java/com/charmroom/charmroom/service/ClubServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/ClubServiceUnitTest.java
@@ -288,15 +288,21 @@ public class ClubServiceUnitTest {
         @Test
         void success() {
             // given
+            User build = User.builder()
+                    .username("updateName")
+                    .email("")
+                    .level(UserLevel.ROLE_BASIC)
+                    .build();
+
             doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
-            doReturn(Optional.of(owner)).when(userRepository).findByUsername(owner.getUsername());
+            doReturn(Optional.of(build)).when(userRepository).findByUsername(build.getUsername());
 
             // when
-            ClubDto dto = clubService.changeOwner(club.getId(), owner.getUsername());
+            ClubDto dto = clubService.changeOwner(club.getId(), build.getUsername(), owner.getUsername());
 
             // then
             assertThat(dto).isNotNull();
-            assertThat(dto.getOwner().getUsername()).isEqualTo(owner.getUsername());
+            assertThat(dto.getOwner().getUsername()).isEqualTo(build.getUsername());
         }
     }
 
@@ -309,7 +315,7 @@ public class ClubServiceUnitTest {
             doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
 
             // when
-            clubService.deleteClub(club.getId());
+            clubService.deleteClub(club.getId(), owner.getUsername());
 
             // then
             verify(clubRepository).delete(any(Club.class));
@@ -322,7 +328,7 @@ public class ClubServiceUnitTest {
 
             // when
             BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> {
-                clubService.deleteClub(club.getId());
+                clubService.deleteClub(club.getId(), owner.getUsername());
             });
 
             // then
@@ -348,7 +354,7 @@ public class ClubServiceUnitTest {
             doReturn(image).when(imageRepository).save(image);
 
             // when
-            ClubDto updated = clubService.setImage(club.getId(), imageFile);
+            ClubDto updated = clubService.setImage(club.getId(), imageFile, owner.getUsername());
 
             // then
             assertThat(updated).isNotNull();
@@ -363,7 +369,7 @@ public class ClubServiceUnitTest {
 
             // when
             BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> {
-                clubService.setImage(club.getId(), imageFile);
+                clubService.setImage(club.getId(), imageFile, owner.getUsername());
             });
 
             // then
@@ -382,6 +388,7 @@ public class ClubServiceUnitTest {
 
             Club club = Club.builder()
                     .image(image)
+                    .owner(owner)
                     .build();
 
             doReturn(Optional.of(club)).when(clubRepository).findById(club.getId());
@@ -390,7 +397,7 @@ public class ClubServiceUnitTest {
             doReturn(image).when(imageRepository).save(image);
 
             // when
-            ClubDto updated = clubService.setImage(club.getId(), imageFile);
+            ClubDto updated = clubService.setImage(club.getId(), imageFile, owner.getUsername());
 
             // then
             verify(uploadUtil).deleteFile(club.getImage());

--- a/src/test/java/com/charmroom/charmroom/service/MarketServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/MarketServiceUnitTest.java
@@ -280,7 +280,7 @@ public class MarketServiceUnitTest {
             doReturn(Optional.of(market)).when(marketRepository).findById(marketId);
 
             // when
-            marketService.delete(marketId);
+            marketService.delete(marketId, user.getUsername());
 
             // then
             verify(marketRepository).delete(market);
@@ -293,7 +293,7 @@ public class MarketServiceUnitTest {
             doReturn(Optional.empty()).when(marketRepository).findById(marketId);
 
             // when
-            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> marketService.delete(marketId));
+            BusinessLogicException thrown = assertThrows(BusinessLogicException.class, () -> marketService.delete(marketId, user.getUsername()));
 
             // then
             assertThat(thrown.getError()).isEqualTo(BusinessLogicError.NOTFOUND_ARTICLE);


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명

Authorize HTTP Request 대신 **Method Security** 방법으로 세분화된 권한을 부여하였다.
- MarketController, ArticleController -> 게시글 조회, 게시글리스트 조회에는 모든 접근을 허용하고, 수정 삭제의 경우 @preAuthorize로 role을 확인한 후, 메서드 호출자와 게시글 작성자가 동일한지 판별하는 로직을 서비스 계층에 추가하였다.
- ClubController -> 조회에는 모든 접근을 허용하고, 수정, 삭제의 경우 클럽 소유자를 판별하는 로직을 서비스 계층에 추가하였다.
- AdminController -> role이 Admin인지 확인하였다.
- UserController -> 로그인 여부만 확인하였다.

<br>

- [x] AdminController
- [x] ClubController
- [x] MarketController
- [x] ArticleController
- [x] UserController

## 참고(선택)
> 리뷰어가 참고할만한 내용

1. 설정 
Method Security는 Spring AOP기반으로 구축되어 있기 때문에, Method Security를 시작하려면 @Configuration이 있는 곳에 **@EnableMethodSecurity**를 추가한다.

2. 메서드 권한 부여
- **@PreAuthroize**
- @PostAuthorize
- @PreFilter
- @PostFilter


https://velog.io/@padomay1352/spring-security-method-%EA%B6%8C%ED%95%9CAhuthorization-%EC%84%A4%EC%A0%95

### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)
Resolves #143

