### PR TITLE
Feat/#162 feed

### DIFF
--- a/src/main/java/com/charmroom/charmroom/controller/api/UserController.java
+++ b/src/main/java/com/charmroom/charmroom/controller/api/UserController.java
@@ -121,7 +121,7 @@ public class UserController {
 	}
 
 	@PreAuthorize("isAuthenticated()")
-	@PostMapping("")
+	@PostMapping("/subscribe")
 	public ResponseEntity<?> subscribe(
 			@RequestBody @Valid SubscribeCreateRequestDto request
 	) {
@@ -138,6 +138,17 @@ public class UserController {
 	) {
 		Page<SubscribeDto> dtos = subscribeService.getSubscribesBySubscriber(user.getUsername(), pageable);
 		Page<SubscribeResponseDto> response = dtos.map(SubscribeMapper::toResponse);
+		return CommonResponseDto.ok(response).toResponseEntity();
+	}
+	
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping("/feed")
+	public ResponseEntity<?> getMyFeeds(
+			@AuthenticationPrincipal User user,
+			@PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+			){
+		var dtos = subscribeService.getArticlesBySubscriber(user.getUsername(), pageable);
+		var response = dtos.map(ArticleMapper::toResponse);
 		return CommonResponseDto.ok(response).toResponseEntity();
 	}
 

--- a/src/main/java/com/charmroom/charmroom/repository/SubscribeRepository.java
+++ b/src/main/java/com/charmroom/charmroom/repository/SubscribeRepository.java
@@ -1,16 +1,27 @@
 package com.charmroom.charmroom.repository;
 
-import com.charmroom.charmroom.entity.Subscribe;
-import com.charmroom.charmroom.entity.User;
-import com.charmroom.charmroom.entity.embid.SubscribeId;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Subscribe;
+import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.embid.SubscribeId;
 
 public interface SubscribeRepository extends JpaRepository<Subscribe, SubscribeId> {
     Optional<Subscribe> findBySubscriberAndTarget(User subscriber, User target);
-
     Page<Subscribe> findAllBySubscriber(User subscriber, Pageable pageable);
+    
+    @Query(
+    		value = "select a from Article a, Subscribe s "
+    				+ "where s.subscriber = :subscriber and a.user = s.target",
+    		countQuery = "select count(a) from Article a, Subscribe s "
+    				+ "where s.subscriber = :subscriber and a.user = s.target"
+    				)
+    Page<Article> findArticlesBySubscriber(@Param("subscriber") User subscriber, Pageable pageable);
 }

--- a/src/main/java/com/charmroom/charmroom/service/SubscribeService.java
+++ b/src/main/java/com/charmroom/charmroom/service/SubscribeService.java
@@ -1,19 +1,24 @@
 package com.charmroom.charmroom.service;
 
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.charmroom.charmroom.dto.business.ArticleDto;
+import com.charmroom.charmroom.dto.business.ArticleMapper;
 import com.charmroom.charmroom.dto.business.SubscribeDto;
 import com.charmroom.charmroom.dto.business.SubscribeMapper;
+import com.charmroom.charmroom.entity.Article;
 import com.charmroom.charmroom.entity.Subscribe;
 import com.charmroom.charmroom.entity.User;
 import com.charmroom.charmroom.exception.BusinessLogicError;
 import com.charmroom.charmroom.exception.BusinessLogicException;
 import com.charmroom.charmroom.repository.SubscribeRepository;
 import com.charmroom.charmroom.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
 
-import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -46,6 +51,11 @@ public class SubscribeService {
         return subscribes.map(SubscribeMapper::toDto);
     }
 
+    public Page<ArticleDto> getArticlesBySubscriber(String subscriberName, Pageable pageable){
+    	User subscriber = findSubscriber(subscriberName);
+    	Page<Article> articles = subscribeRepository.findArticlesBySubscriber(subscriber, pageable);
+    	return articles.map(ArticleMapper::toDto);
+    }
     private User findSubscriber(String subscriberName) {
         return userRepository.findByUsername(subscriberName).orElseThrow(() ->
                 new BusinessLogicException(BusinessLogicError.NOTFOUND_USER, "subscriberName: " + subscriberName));

--- a/src/test/java/com/charmroom/charmroom/controller/integration/AdControllerIntegrationTestDy.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/AdControllerIntegrationTestDy.java
@@ -31,8 +31,8 @@ public class AdControllerIntegrationTestDy extends IntegrationTestBase {
 		return adRepository.save(Ad.builder()
 				.title(s)
 				.link(s)
-				.start(LocalDateTime.of(2024, 8, 28, 0, 0))
-				.end(LocalDateTime.of(2024, 8, 30, 0, 0))
+				.start(LocalDateTime.of(1990, 8, 28, 0, 0))
+				.end(LocalDateTime.of(2999, 8, 30, 0, 0))
 				.image(image)
 				.build());
 	}

--- a/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/integration/UserControllerIntegrationTestCm.java
@@ -120,7 +120,7 @@ public class UserControllerIntegrationTestCm extends IntegrationTestBase {
 
     @Nested
     class CreateSubscribe {
-        MockHttpServletRequestBuilder request = post("/api/user");
+        MockHttpServletRequestBuilder request = post("/api/user/subscribe");
         @Autowired
         SubscribeRepository subscribeRepository;
         @Autowired

--- a/src/test/java/com/charmroom/charmroom/controller/unit/UserControllerUnitTestCm.java
+++ b/src/test/java/com/charmroom/charmroom/controller/unit/UserControllerUnitTestCm.java
@@ -179,7 +179,7 @@ public class UserControllerUnitTestCm {
             doReturn(dto).when(subscribeService).subscribeOrCancel(any(), any());
 
             // when
-            ResultActions resultActions = mockMvc.perform(post("/api/user")
+            ResultActions resultActions = mockMvc.perform(post("/api/user/subscribe")
                     .content(gson.toJson(requestDto))
                     .contentType(MediaType.APPLICATION_JSON));
 

--- a/src/test/java/com/charmroom/charmroom/service/SubscribeServiceUnitTest.java
+++ b/src/test/java/com/charmroom/charmroom/service/SubscribeServiceUnitTest.java
@@ -1,8 +1,11 @@
 package com.charmroom.charmroom.service;
 
 import com.charmroom.charmroom.dto.business.SubscribeDto;
+import com.charmroom.charmroom.entity.Article;
+import com.charmroom.charmroom.entity.Board;
 import com.charmroom.charmroom.entity.Subscribe;
 import com.charmroom.charmroom.entity.User;
+import com.charmroom.charmroom.entity.enums.BoardType;
 import com.charmroom.charmroom.repository.SubscribeRepository;
 import com.charmroom.charmroom.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -133,5 +137,41 @@ public class SubscribeServiceUnitTest {
             // then
             assertThat(result).hasSize(3);
         }
+    }
+    
+    @Nested
+    class GetArticlesBySubscriber{
+    	@Test
+    	void success() {
+    		// given
+    		User target = createUser("target1");
+    		User subscriber = createUser("subscriber");
+    		
+    		List<Article> articles = new ArrayList<>();
+    		
+    		for(int i = 0; i < 3; i++) {
+    			articles.add(Article.builder()
+    					.board(Board.builder()
+    							.name(Integer.toString(i))
+    							.type(BoardType.LIST)
+    							.build())
+    					.user(target)
+    					.title(Integer.toString(i))
+    					.body("")
+    					.build());
+    		}
+    		
+    		var pageImpl = new PageImpl<>(articles);
+    		var pr = PageRequest.of(0, 10);
+    		
+    		doReturn(Optional.of(subscriber)).when(userRepository).findByUsername(subscriber.getUsername());
+    		doReturn(pageImpl).when(subscribeRepository).findArticlesBySubscriber(subscriber, pr);
+    		
+    		// when
+    		var result = subscribeService.getArticlesBySubscriber(subscriber.getUsername(), pr);
+    		
+    		// then
+    		assertThat(result).hasSize(3);
+    	}
     }
 }


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명

### 피드 (구독한 글 조회) 기능 추가
  - 엔드포인트: `/api/user/feed`
  - 구독하고 있는 target의 글 조회 (pageable 지원)

### 구독 요청 주소 변경
  - 기존: `/api/user` -> 변경: `/api/user/subscribe`

## 참고(선택)
> 리뷰어가 참고할만한 내용



### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)

Resolves #162 

